### PR TITLE
support new/bad measurement schedule items

### DIFF
--- a/android/src/com/mobiperf/speedometer/util/MeasurementJsonConvertor.java
+++ b/android/src/com/mobiperf/speedometer/util/MeasurementJsonConvertor.java
@@ -81,8 +81,8 @@ public class MeasurementJsonConvertor {
 			Class taskClass = MeasurementTask.getTaskClassForMeasurement(type);
 			// if the task type doesn't exist (new unsupported type), taskClass 
 			// will be null so we have to fail fast
-			if (taskClass==null){
-				throw new IllegalArgumentException("Unknown type: "+type);
+			if (taskClass == null) {
+				throw new IllegalArgumentException("Unknown type: " + type);
 			}
 			Method getDescMethod = taskClass.getMethod("getDescClass");
 			// The getDescClassForMeasurement() is static and takes no arguments

--- a/android/src/com/mobiperf/speedometer/util/MeasurementJsonConvertor.java
+++ b/android/src/com/mobiperf/speedometer/util/MeasurementJsonConvertor.java
@@ -79,6 +79,11 @@ public class MeasurementJsonConvertor {
 		try {
 			String type = String.valueOf(json.getString("type"));
 			Class taskClass = MeasurementTask.getTaskClassForMeasurement(type);
+			// if the task type doesn't exist (new unsupported type), taskClass 
+			// will be null so we have to fail fast
+			if (taskClass==null){
+				throw new IllegalArgumentException("Unknown type: "+type);
+			}
 			Method getDescMethod = taskClass.getMethod("getDescClass");
 			// The getDescClassForMeasurement() is static and takes no arguments
 			Class descClass = (Class) getDescMethod.invoke(null,


### PR DESCRIPTION
This prevents an uncaught NPE that would be thrown by a checkin. The NPE occurs when we add a new measurement type to the schedule that is not supported by an old version of the app. 

I thought about using different versions of the GAE instance to support this case instead, but it doesn't work easily because the measurement schedule data (i.e., the datastore) is shared across all versions of the server. In the future, we could return measurement types according to the version number reported by the app that is checking in. 

The above approach can be painful to maintain, so to avoid that complexity and to ensure that we don't bring down all measurements with bugs on the server side, I sugest we handle unexpected cases in the app logic.
