### PR TITLE
An intermediate update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+android/bin/
+
+android/gen/com/mobiperf/mobiperf/R.java

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -14,7 +14,7 @@
   <uses-permission android:name="android.permission.BATTERY_STATS" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
-  <uses-sdk android:targetSdkVersion="9" android:minSdkVersion="9" />
+  <uses-sdk android:targetSdkVersion="9" android:minSdkVersion="8" />
     
   <application android:icon="@drawable/icon" android:label="@string/app_name" android:debuggable="true">
     <activity android:label="@string/app_name" 
@@ -61,6 +61,7 @@
       android:name="com.mobiperf.speedometer.speed.MeasurementCreationActivity"
       android:launchMode="singleTask">
     </activity>
+    <receiver android:name="com.mobiperf.speedometer.speed.PeriodicTest"></receiver>
   </application>
 
 </manifest>

--- a/android/res/layout/about.xml
+++ b/android/res/layout/about.xml
@@ -42,7 +42,7 @@
             android:scrollbars="vertical" 
              android:singleLine="false"
              android:textColor="@android:color/secondary_text_dark_nodisable"
-            android:text="We are Junxian Huang, Cheng Chen and Yutong Pei, students in the Department of Computer Science, the University of Michigan, Ann Arbor. We work with Prof. Z. Morley Mao in collaboration with Dr. Ming Zhang and Victor Bahl from Microsoft Research. The project is also partially funded by University of Michigan, NSF, and CISCO. And we are actively looking for other sources of funding to improve the tool." 
+            android:text="About text here" 
             /> 
             
             <TextView

--- a/android/res/layout/home.xml
+++ b/android/res/layout/home.xml
@@ -22,11 +22,6 @@
 		android:text="@string/btn_network_toggle"
 		android:drawableTop="@drawable/home_btn_networktoggle" />
 		 
-	<Button android:id="@+id/home_btn_about" 
-		style="@style/DashboardButton"
-		android:text="@string/btn_about" 
-		android:drawableTop="@drawable/home_btn_performance" />		
-	
 	<Button android:id="@+id/home_btn_taskqueue" 
 		style="@style/DashboardButton"
 		android:text="Task Queue" 
@@ -35,6 +30,12 @@
 	<Button android:id="@+id/home_btn_settings" 
 		style="@style/DashboardButton"
 		android:text="@string/btn_settings" 
-		android:drawableTop="@drawable/home_btn_settings" />	
+		android:drawableTop="@drawable/home_btn_settings" />
+	
+	<Button android:id="@+id/home_btn_about" 
+		style="@style/DashboardButton"
+		android:text="@string/btn_about" 
+		android:drawableTop="@drawable/home_btn_performance" />		
+		
 
 </com.mobiperf.mobiperf.DashboardLayout>

--- a/android/res/layout/preferences.xml
+++ b/android/res/layout/preferences.xml
@@ -11,7 +11,7 @@
             <com.mobiperf.mobiperf.TimeSetting
                 android:key="duration"
         		android:title="Test period "
-        		android:summary="Set specific time for periodic running"
+        		android:summary="Set specific time for periodic running, disable and then re-enable periodic running to make the new setting effective"
         		android:dialogMessage="Period"
         		android:defaultValue="5"
         		android:text=" Hours"

--- a/android/res/layout/preferences.xml
+++ b/android/res/layout/preferences.xml
@@ -17,6 +17,13 @@
         		android:text=" Hours"
         		android:max="97"
          		android:dependency="PeriodicPref"/>
+      		<ListPreference
+      		    android:title="Periodic Test"
+      		    android:summary="Select the test to be run periodically"
+      		    android:key="periodtestPref"
+                android:entries="@array/listArray"
+                android:entryValues="@array/listArray"
+                android:dependency="PeriodicPref" />
             <EditTextPreference
     			android:defaultValue="1"
     			android:summary="The interval (hours) speedometer fetches and pushes measurements"

--- a/android/res/layout/preferences.xml
+++ b/android/res/layout/preferences.xml
@@ -26,7 +26,7 @@
                 android:dependency="PeriodicPref" />
             <EditTextPreference
     			android:defaultValue="1"
-    			android:summary="The interval (hours) speedometer fetches and pushes measurements"
+    			android:summary="The interval (hours) MobiPerf fetches and pushes measurements"
     			android:key="checkinIntervalPref" 
     			android:inputType="number" 
     			android:title="Checkin Interval (hour)"/>    

--- a/android/res/values/array.xml
+++ b/android/res/values/array.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="listArray">
+        <item>HTTP</item>
+        <item>Traceroute</item>
+        <item>Ping</item>
+        <item>DNS Lookup</item>
+        <item>All</item>
+    </string-array>
+</resources>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -2,14 +2,14 @@
 <resources>
     <string name="app_name">Mobiperf</string>
     <string name="ping_executable">/system/bin/ping</string>
-    <string name="speedometerServerUrl">https://openmobiledata.appspot.com</string>
+    <string name="serverUrl">https://openmobiledata.appspot.com</string>
     <string name="menuQuit">Quit</string>
     <string name="menumPause">Pause</string>
     <string name="pauseMessage">Mobiperf is paused.</string>
     <string name="menuResume">Resume</string>
     <string name="resumeMessage">Mobiperf is running.</string>
     <string name="user_agent">Linux; Android</string>
-    <string name="default_user_agent">"Speedometer-1.0 (Linux; Android)"</string>
+    <string name="default_user_agent">"MobiPerf-1.0 (Linux; Android)"</string>
     <string name="menuSettings">Settings</string>
     <string name="menuAbout">About</string>
     <string name="menuLog">System Log</string>
@@ -31,7 +31,7 @@
     <string name="batteryMinThresPrefKey">batteryMinThresPref</string>
     <string name="startOnBootPrefKey">KEY_START_ON_BOOT</string>
     <string name="notificationSchedulerStarted">Mobiperf service has started</string>
-    <string name="notificatioContent">Speedometer service is running</string>
+    <string name="notificatioContent">MobiPerf service is running</string>
     <string name="userMeasurementSuccessToast">Measurement is running. Results will show up shortly.</string>
     <string name="userMeasurementFailureToast">The scheduler is busy, please run the measurement later</string>
     <string name="userMeasurementBusySchedulerToast">The scheduler is busy, your measurement will start shortly</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -25,9 +25,10 @@
     <string name="httpHeadRadioText">Head</string>
     <string name="httpUrlHint">www.google.com</string>
     <string name="httpUrlLabel">URL Address</string>
-    <string name="checkinIntervalPrefKey">KEY_CHEKCEDIN_INTERVAL</string>
+    <string name="checkinIntervalPrefKey">checkinIntervalPref</string>
+    <string name="periodtestPrefKey">periodtestPref</string>
     <string name="measureWhenPluggedPrefKey">KEY_MEASURE_WHEN_PLUGGED</string>
-    <string name="batteryMinThresPrefKey">KEY_BATTERY_THRES</string>
+    <string name="batteryMinThresPrefKey">batteryMinThresPref</string>
     <string name="startOnBootPrefKey">KEY_START_ON_BOOT</string>
     <string name="notificationSchedulerStarted">Mobiperf service has started</string>
     <string name="notificatioContent">Speedometer service is running</string>
@@ -44,4 +45,5 @@
     <string name="btn_settings">Settings</string>
     <string name="btn_about">About Us</string>
     <string name="btn_network_toggle">Switch 3G/4G</string>
+    <string name="periodtest_prompt">Select the test to be run periodically.</string>
 </resources>

--- a/android/src/com/mobiperf/mobiperf/Preferences.java
+++ b/android/src/com/mobiperf/mobiperf/Preferences.java
@@ -14,8 +14,11 @@
  */
 package com.mobiperf.mobiperf;
 
+import com.mobiperf.mobiperf.TimeSetting;
 import com.mobiperf.mobiperf.R;
+import com.mobiperf.speedometer.speed.Config;
 import com.mobiperf.speedometer.speed.Logger;
+import com.mobiperf.speedometer.speed.PeriodicTest;
 
 import android.app.AlarmManager;
 import android.app.AlertDialog;
@@ -27,6 +30,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.Preference.OnPreferenceClickListener;
@@ -84,9 +88,9 @@ public class Preferences extends PreferenceActivity {
 						boolean CheckboxPreference = prefs.getBoolean(
 								"PeriodicPref", true);
 						if (CheckboxPreference == true) {
-							enablePeriodicalRun(Preferences.this);
+							//enablePeriodicalRun(Preferences.this);
 							Toast.makeText(getApplicationContext(),
-									"enabled the periodic running",
+									"enabled periodic running",
 									Toast.LENGTH_SHORT).show();
 						}
 						if (CheckboxPreference == false) {
@@ -102,6 +106,7 @@ public class Preferences extends PreferenceActivity {
 		
 		Preference intervalPref = (Preference) findPreference("checkinIntervalPref");
 		Preference batteryPref = (Preference) findPreference("batteryMinThresPref");
+		Preference periodPref = (Preference) findPreference("periodtestPref");
 		
 		OnPreferenceChangeListener prefChangeListener = new OnPreferenceChangeListener() {
 			@Override
@@ -145,6 +150,9 @@ public class Preferences extends PreferenceActivity {
 						Logger.e("Cannot cast battery preference value to Integer");
 						return false;
 					}
+				} else if (prefKey
+						.compareTo(getString(R.string.periodtestPrefKey)) == 0) {
+					enablePeriodicalRun(Preferences.this, (String) newValue);
 				}
 				return true;
 			}
@@ -152,7 +160,7 @@ public class Preferences extends PreferenceActivity {
 		
 		intervalPref.setOnPreferenceChangeListener(prefChangeListener);
 		batteryPref.setOnPreferenceChangeListener(prefChangeListener);
-		
+		periodPref.setOnPreferenceChangeListener(prefChangeListener);
 	}
 
 	public static boolean getSharedPreferences(Context ctxt) {
@@ -174,7 +182,7 @@ public class Preferences extends PreferenceActivity {
 						public void onClick(DialogInterface dialog, int item) {
 							switch (item) {
 							case PERIODIC_YES:
-								enablePeriodicalRun(Preferences.this);
+								//enablePeriodicalRun(Preferences.this);
 								break;
 							case PERIODIC_NO:
 								disablePeriodicalRun(Preferences.this);
@@ -253,18 +261,58 @@ public class Preferences extends PreferenceActivity {
 		return true;
 	}
 
-	/**
-	 *  TODO(huangshu): Removed all the old periodic code. Merge with speedometer periodic.
-	 *
-	 */
-	public static void enablePeriodicalRun(Context context) {
+	public static void enablePeriodicalRun(Context context, String periodtest) {
+		
+		Intent intent = new Intent(context, PeriodicTest.class);
+    	PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 
+    			Config.PERIODIC_REQUEST_CODE, intent, PendingIntent.FLAG_NO_CREATE);
+    	
+    	if(pendingIntent != null){
+    	}else{
+    		// Create new pending intent
+    		Bundle b = new Bundle();
+    		b.putString("test", periodtest);
+    		intent.putExtras(b);
+    		pendingIntent = PendingIntent.getBroadcast(context, Config.PERIODIC_REQUEST_CODE, intent, 0);
+    		AlarmManager alarmManager = (AlarmManager) context.getSystemService(ALARM_SERVICE);
+    		
+    		int interval = TimeSetting.getProgress()+10;
+    		
+    		//If less than 60, this is in minutes
+    		if (interval < 60) interval = interval * 1000 * 60;
+    		else {
+    			interval = interval - 59;
+    			interval = interval * 1000 * 3600;
+    		}
+			
+        	alarmManager.setRepeating(AlarmManager.RTC_WAKEUP, 
+        			System.currentTimeMillis() + Config.PERIODIC_FIRST_RUN_STARTING_DELAY, 
+        			interval, pendingIntent);
+        	
+    	}
+	
 	}
 
 	public static void disablePeriodicalRun(Context context) {
+		Intent intent = new Intent(context, PeriodicTest.class);
+    	PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 
+    			Config.PERIODIC_REQUEST_CODE, intent, PendingIntent.FLAG_NO_CREATE);
+    	if(pendingIntent != null){
+    		AlarmManager alarmManager = (AlarmManager) context.getSystemService(ALARM_SERVICE);
+    		// Cancel alarm
+    		alarmManager.cancel(pendingIntent);
+    		// Remove the pending intent
+    		pendingIntent.cancel();
+    	}
 	}
 
 	public static boolean isPeriodicalRunEnabled(Context context) {
-		return true;
+		Intent intent = new Intent(context, PeriodicTest.class);
+    	PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 
+    			Config.PERIODIC_REQUEST_CODE, intent, PendingIntent.FLAG_NO_CREATE);
+    	if(pendingIntent == null)
+    		return false;
+    	return true;
 	}
 
 	private static void clearNotification(Context context) {

--- a/android/src/com/mobiperf/mobiperf/Preferences.java
+++ b/android/src/com/mobiperf/mobiperf/Preferences.java
@@ -88,7 +88,8 @@ public class Preferences extends PreferenceActivity {
 						boolean CheckboxPreference = prefs.getBoolean(
 								"PeriodicPref", true);
 						if (CheckboxPreference == true) {
-							//enablePeriodicalRun(Preferences.this);
+							//by default, we run all tests periodically
+							enablePeriodicalRun(Preferences.this, "all"); 
 							Toast.makeText(getApplicationContext(),
 									"enabled periodic running",
 									Toast.LENGTH_SHORT).show();
@@ -132,8 +133,7 @@ public class Preferences extends PreferenceActivity {
 						Logger.e("Cannot cast checkin interval preference value to Integer");
 						return false;
 					}
-				} else if (prefKey
-						.compareTo(getString(R.string.batteryMinThresPrefKey)) == 0) {
+				} else if (prefKey.compareTo(getString(R.string.batteryMinThresPrefKey)) == 0) {
 					try {
 						Integer val = Integer.parseInt((String) newValue);
 						if (val < 0 || val > 100) {
@@ -150,8 +150,9 @@ public class Preferences extends PreferenceActivity {
 						Logger.e("Cannot cast battery preference value to Integer");
 						return false;
 					}
-				} else if (prefKey
-						.compareTo(getString(R.string.periodtestPrefKey)) == 0) {
+				} else if (prefKey.compareTo(getString(R.string.periodtestPrefKey)) == 0) {
+					//when new test is selected, disable first and then enalbe with new selected tests.
+					disablePeriodicalRun(Preferences.this);
 					enablePeriodicalRun(Preferences.this, (String) newValue);
 				}
 				return true;
@@ -261,6 +262,11 @@ public class Preferences extends PreferenceActivity {
 		return true;
 	}
 
+	/**
+	 * This is called when the "Periodic Running" is checked
+	 * @param context
+	 * @param periodtest
+	 */
 	public static void enablePeriodicalRun(Context context, String periodtest) {
 		
 		Intent intent = new Intent(context, PeriodicTest.class);

--- a/android/src/com/mobiperf/speedometer/speed/Config.java
+++ b/android/src/com/mobiperf/speedometer/speed/Config.java
@@ -22,6 +22,10 @@ package com.mobiperf.speedometer.speed;
  * 
  */
 public interface Config {
+	
+	public static final String ALLTASK_TYPE = "all";
+	public static final String DEFAULT_TEST_URL = "google.com";
+	
 	public static final boolean DEFAULT_START_ON_BOOT = true;
 	/** Constants used in various measurement tasks */
 	public static final float RESOURCE_UNREACHABLE = Float.MAX_VALUE;

--- a/android/src/com/mobiperf/speedometer/speed/MeasurementCreationActivity.java
+++ b/android/src/com/mobiperf/speedometer/speed/MeasurementCreationActivity.java
@@ -145,7 +145,7 @@ public class MeasurementCreationActivity extends Activity {
 			MeasurementTask newTask = null;
 			boolean showLengthWarning = false;
 			try {
-				if (measurementTypeUnderEdit.equals(PingTask.TYPE)) {
+				if (measurementTypeUnderEdit.equals(PingTask.TYPE) || measurementTypeUnderEdit.equals(Config.ALLTASK_TYPE)) {
 					EditText pingTargetText = (EditText) findViewById(R.id.pingTargetText);
 					Map<String, String> params = new HashMap<String, String>();
 					params.put("target", pingTargetText.getText().toString());
@@ -157,7 +157,9 @@ public class MeasurementCreationActivity extends Activity {
 					newTask = new PingTask(desc,
 							MeasurementCreationActivity.this
 									.getApplicationContext());
-				} else if (measurementTypeUnderEdit.equals(HttpTask.TYPE)) {
+				} 
+
+				if (measurementTypeUnderEdit.equals(HttpTask.TYPE) || measurementTypeUnderEdit.equals(Config.ALLTASK_TYPE)) {
 					EditText httpUrlText = (EditText) findViewById(R.id.httpUrlText);
 					Map<String, String> params = new HashMap<String, String>();
 					params.put("url", httpUrlText.getText().toString());
@@ -170,7 +172,9 @@ public class MeasurementCreationActivity extends Activity {
 					newTask = new HttpTask(desc,
 							MeasurementCreationActivity.this
 									.getApplicationContext());
-				} else if (measurementTypeUnderEdit.equals(TracerouteTask.TYPE)) {
+				}
+
+				if (measurementTypeUnderEdit.equals(TracerouteTask.TYPE) || measurementTypeUnderEdit.equals(Config.ALLTASK_TYPE)) {
 					EditText targetText = (EditText) findViewById(R.id.tracerouteTargetText);
 					Map<String, String> params = new HashMap<String, String>();
 					params.put("target", targetText.getText().toString());
@@ -183,7 +187,9 @@ public class MeasurementCreationActivity extends Activity {
 							MeasurementCreationActivity.this
 									.getApplicationContext());
 					showLengthWarning = true;
-				} else if (measurementTypeUnderEdit.equals(DnsLookupTask.TYPE)) {
+				} 
+
+				if (measurementTypeUnderEdit.equals(DnsLookupTask.TYPE) || measurementTypeUnderEdit.equals(Config.ALLTASK_TYPE)) {
 					EditText dnsTargetText = (EditText) findViewById(R.id.dnsLookupText);
 					Map<String, String> params = new HashMap<String, String>();
 					params.put("target", dnsTargetText.getText().toString());

--- a/android/src/com/mobiperf/speedometer/speed/PeriodicTest.java
+++ b/android/src/com/mobiperf/speedometer/speed/PeriodicTest.java
@@ -1,9 +1,23 @@
 package com.mobiperf.speedometer.speed;
 
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+
+import com.mobiperf.mobiperf.MobiperfActivity;
+import com.mobiperf.speedometer.measurements.DnsLookupTask;
+import com.mobiperf.speedometer.measurements.DnsLookupTask.DnsLookupDesc;
+import com.mobiperf.speedometer.measurements.HttpTask;
+import com.mobiperf.speedometer.measurements.HttpTask.HttpDesc;
+import com.mobiperf.speedometer.measurements.PingTask;
+import com.mobiperf.speedometer.measurements.PingTask.PingDesc;
+import com.mobiperf.speedometer.measurements.TracerouteTask;
+import com.mobiperf.speedometer.measurements.TracerouteTask.TracerouteDesc;
 
 public class PeriodicTest extends BroadcastReceiver{
 
@@ -11,6 +25,74 @@ public class PeriodicTest extends BroadcastReceiver{
 	public void onReceive(Context context, Intent intent) {
 		Bundle b = intent.getExtras();
 		String schedtest = b.getString("test");
+		
+		MeasurementTask newTask = null;
+		try {
+			if (schedtest.equals(PingTask.TYPE) || schedtest.equals(Config.ALLTASK_TYPE)) {
+				Map<String, String> params = new HashMap<String, String>();
+				params.put("target", Config.DEFAULT_TEST_URL);
+				PingDesc desc = new PingDesc(null, Calendar.getInstance()
+						.getTime(), null,
+						Config.DEFAULT_USER_MEASUREMENT_INTERVAL_SEC,
+						Config.DEFAULT_USER_MEASUREMENT_COUNT,
+						MeasurementTask.USER_PRIORITY, params);
+				newTask = new PingTask(desc, context.getApplicationContext());
+			} 
+
+			if (schedtest.equals(HttpTask.TYPE) || schedtest.equals(Config.ALLTASK_TYPE)) {
+				Map<String, String> params = new HashMap<String, String>();
+				params.put("url", Config.DEFAULT_TEST_URL);
+				params.put("method", "get");
+				HttpDesc desc = new HttpDesc(null, Calendar.getInstance()
+						.getTime(), null,
+						Config.DEFAULT_USER_MEASUREMENT_INTERVAL_SEC,
+						Config.DEFAULT_USER_MEASUREMENT_COUNT,
+						MeasurementTask.USER_PRIORITY, params);
+				newTask = new HttpTask(desc, context.getApplicationContext());
+			}
+
+			if (schedtest.equals(TracerouteTask.TYPE) || schedtest.equals(Config.ALLTASK_TYPE)) {
+				
+				Map<String, String> params = new HashMap<String, String>();
+				params.put("target", Config.DEFAULT_TEST_URL);
+				TracerouteDesc desc = new TracerouteDesc(null, Calendar
+						.getInstance().getTime(), null,
+						Config.DEFAULT_USER_MEASUREMENT_INTERVAL_SEC,
+						Config.DEFAULT_USER_MEASUREMENT_COUNT,
+						MeasurementTask.USER_PRIORITY, params);
+				newTask = new TracerouteTask(desc, context.getApplicationContext());
+			} 
+
+			if (schedtest.equals(DnsLookupTask.TYPE) || schedtest.equals(Config.ALLTASK_TYPE)) {
+				
+				Map<String, String> params = new HashMap<String, String>();
+				params.put("target", Config.DEFAULT_TEST_URL);
+				DnsLookupDesc desc = new DnsLookupDesc(null, Calendar
+						.getInstance().getTime(), null,
+						Config.DEFAULT_USER_MEASUREMENT_INTERVAL_SEC,
+						Config.DEFAULT_USER_MEASUREMENT_COUNT,
+						MeasurementTask.USER_PRIORITY, params);
+				newTask = new DnsLookupTask(desc, context.getApplicationContext());
+			}
+
+			if (newTask != null) {
+				MeasurementScheduler scheduler = MobiperfActivity.scheduler;
+				if (scheduler != null && scheduler.submitTask(newTask)) {
+					// Broadcast an intent with MEASUREMENT_ACTION so that
+					// the scheduler will immediately
+					// handles the user measurement
+
+					context.sendBroadcast(new UpdateIntent("",
+							UpdateIntent.MEASUREMENT_ACTION));
+					// startActivity(new Intent(this,
+					// ResultsConsole.class).setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP
+					// | Intent.FLAG_ACTIVITY_CLEAR_TOP));
+				}
+			}
+
+		} catch (Exception e) {
+			Logger.e("Exception when creating user measurements", e);
+		}
 		
 	}
 }

--- a/android/src/com/mobiperf/speedometer/speed/PeriodicTest.java
+++ b/android/src/com/mobiperf/speedometer/speed/PeriodicTest.java
@@ -1,0 +1,16 @@
+package com.mobiperf.speedometer.speed;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class PeriodicTest extends BroadcastReceiver{
+
+	@Override
+	public void onReceive(Context context, Intent intent) {
+		Bundle b = intent.getExtras();
+		String schedtest = b.getString("test");
+		
+	}
+}

--- a/android/src/com/mobiperf/speedometer/util/PhoneUtils.java
+++ b/android/src/com/mobiperf/speedometer/util/PhoneUtils.java
@@ -665,7 +665,7 @@ public class PhoneUtils {
 	}
 
 	public String getServerUrl() {
-		return context.getResources().getString(R.string.speedometerServerUrl);
+		return context.getResources().getString(R.string.serverUrl);
 	}
 
 	public boolean isTestingServer(String serverUrl) {


### PR DESCRIPTION
This update includes the code changes from @huangshu91 and some minor naming/layout changes.

The changes from @huangshu91 is described by him as follows:

"Changes I made are I added an additional option under periodic testing which allows the user to select the test to run. The test to run is included in the bundle for the pending intent and broadcasted to PeriodicTest within the package com.mobiperf.speedometer.speed.  I tested and everything so far is working however I did not add any actual logic for adding the test to the measurementscheduler.  I realized that one problem with this is that there is no fields for the user to select url or options that are included in the normal measurement selection.  I was unsure of what to do in this situation so I left the logic after receiving the broadcast blank.  However this can be easily fixed by just copy pasting the code from the MeasurementScheduleConsoleActivity.  If this fix is used it is a very simple cut and paste while setting the url to be a hardcoded url and should take no more than a few minutes."
