### PR TITLE
Archive dev

### DIFF
--- a/server/download_dev_data.sh
+++ b/server/download_dev_data.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Author: gavaletz@google.com (Eric Gavaletz)
+
+# This script downloads data from the Speedometer service running on AppEngine.
+# For more information on options try "appcfg.py --help" or
+# https://developers.google.com/appengine/docs/python/tools/uploadingdata#Downloading_and_Uploading_All_Data
+
+# WARNING: this will produce a very heavy load on the GAE instance and eat up a
+# lot of the applicaion's quota.  Please check to see if there is an existing
+# download that you can use before using this.
+
+. ./script_config.sh
+
+mv $DATA_PATH $DATA_PATH.back
+
+$PYTHON $APPCFG -e $USER_EMAIL -A s~$APP_ID download_data \
+  --num_threads=10 \
+  --batch_size=10 \
+  --bandwidth_limit=1073741824 \
+  --rps_limit=20 \
+  --http_limit=7.5 \
+  --url=http://$APP_ID.$APP_DOMAIN/_ah/remote_api \
+  --log_file=$DATA_PATH/bulkloader-log-down \
+  --db_filename=$DATA_PATH/bulkloader-progress-down.sql3 \
+  --result_db_filename=$DATA_PATH/bulkloader-results-down.sql3 \
+  --filename=$DOWNLOAD_DATA_PATH
+
+#TODO(user) uncomment here if you want things kept clean
+# This carries with it a risk of local data loss
+#rm $DATASTORE_PATH $DATA_PATH.back

--- a/server/run_server_locally.sh
+++ b/server/run_server_locally.sh
@@ -1,23 +1,17 @@
 #!/bin/sh
 #
-# Author: mdw@google.com (Matt Welsh)
+# Author: mdw@google.com (Matt Welsh), gavaletz@google.com (Eric Gavaletz)
 
 # For more information on options try "dev_appserver.py --help" or
 # https://developers.google.com/appengine/docs/python/tools/devserver
 
-PYTHON=python
-APPSERVER=`which dev_appserver.py`
+. ./script_config.sh
 
-BLOBSTORE_PATH=dev_data
-DATASTORE_PATH=dev_data/dev_appserver.datastore
-
-CLEAN=""
-#TODO(user) if having trouble with the datastore try uncommenting this
-#CLEAN="-c"
-
-./set_version.sh --notag
-
-$PYTHON $APPSERVER $CLEAN -d .
-#TODO(user) use the following line for testing large data operations
-#$PYTHON $APPSERVER $CLEAN -d --backends --blobstore_path=$BLOBSTORE_PATH \
+$PYTHON $APPSERVER $CLEAN $DEBUG $ADDRESS .
+#TODO(user) use the following line(s) for testing large data operations
+#$PYTHON $APPSERVER $CLEAN $DEBUG $ADDRESS\
+#  --high_replication \
+#  --backends \
+#  --use_sqlite \
+#  --blobstore_path=$DATA_PATH \
 #  --datastore_path=$DATASTORE_PATH .

--- a/server/script_config.sh
+++ b/server/script_config.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Author: gavaletz@google.com (Eric Gavaletz)
+
+# Because of the growing number of scripts there was a growing number of
+# dependencies and variables being set in lots of different locations.  This
+# script is an attempt to get all of those in one place.  To use these
+# in any script simply source it as such.  
+#
+# . ./script_config.sh
+#
+# Note that this will execute the contents on this script each time that it is
+# sourced so nothing in this file should produce side effects.
+
+
+# NOTE on python versions:
+# Because a lot of systems have a default python version newer than 2.5 it is
+# necessary to be more precise about which python we want to use for running
+# the dev_appserver.  If you do not use 2.5, then it will give you warnings but
+# more importantly it is possible that you could include something that works
+# with the newer version of python that you use locally and it will break your
+# code once it is uploaded to the development GAE instance.
+
+PYTHON=python2.5
+APPCFG=`which appcfg.py`
+APPSERVER=`which dev_appserver.py`
+
+
+APP_ID=`cat app.yaml.tmpl | grep application | cut -d " " -f 2`
+APP_DOMAIN=appspot.com
+VERSION=`./set_version.sh`
+
+
+USER_EMAIL=`git config user.email`
+
+
+# These are used for downloading data from the production environment, and using
+# it with the dev_appserver.  See download_dev_data.sh and upload_local_data.sh
+# for more information.
+
+DATA_PATH=dev_data
+DOWNLOAD_DATA_PATH=$DATA_PATH/datastore.sql3
+DATASTORE_PATH=$DATA_PATH/dev_appserver.datastore
+
+
+# These are used for running the local dev_appserver.  These will not effect the
+# application as deployed on GAE.
+
+DEBUG=""
+#TODO(user) If having trouble try using this.
+#DEBUG="-d"
+
+CLEAN=""
+#TODO(user) If having trouble with the datastore try uncommenting this.
+#CLEAN="-c"
+
+ADDRESS=""
+#TODO(user) If you need to bind to a local address uncomment and adjust this.
+#ADDRESS="--address=192.168.1.128"

--- a/server/update_dev_server.sh
+++ b/server/update_dev_server.sh
@@ -6,14 +6,7 @@
 # For more information on options try "appcfg.py --help" or
 # https://developers.google.com/appengine/docs/python/tools/uploadinganapp
 
-PYTHON=python
-APPCFG=`which appcfg.py`
-
-VERSION=`./set_version.sh`
-
-APP_ID=openmobiledata
-USER_EMAIL=`git config user.email`
-APP_DOMAIN=appspot.com
+. ./script_config.sh
 
 $PYTHON $APPCFG -e $USER_EMAIL -A $APP_ID update .
 

--- a/server/upload_local_data.sh
+++ b/server/upload_local_data.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Author: gavaletz@google.com (Eric Gavaletz)
+
+# This script laods data from the Speedometer service running on AppEngine to
+# dev_appserver.  For more information on options try "appcfg.py --help" or
+# https://developers.google.com/appengine/docs/python/tools/uploadingdata#Downloading_and_Uploading_All_Data
+
+# To use this you should either have obtained an sql3 file from someone that
+# has already run download_data.sh or run it yourself.  Make sure that the
+# dev_appserver is running with the datastore development options selected see
+# run_server_locally.sh for details.  This is not intended to update data on
+# the GAE instance (really you shouldn't be doing that).
+
+. ./script_config.sh
+
+$PYTHON $APPCFG -e $USER_EMAIL -A dev~$APP_ID upload_data \
+  --url=http://localhost:8080/_ah/remote_api \
+  --log_file=$DATA_PATH/bulkloader-log-up \
+  --db_filename=$DATA_PATH/bulkloader-progress-up.sql3 \
+  --filename=$DATA_PATH


### PR DESCRIPTION
This adds two new scripts for getting data from GAE onto your local machine and into the dev_appserver, one script that has settings that are common for some of the other scripts, and a re-factoring change.  **To be crystal clear**, _this is a development tool, and should not be used as part of the production environment._

To use these you will need to be on the right ACL within GAE (data cannot be downloaded by anyone with this script).
