### PR TITLE
measurement scheduler interface upgrade

### DIFF
--- a/server/gspeedometer/config.py
+++ b/server/gspeedometer/config.py
@@ -30,7 +30,7 @@ NUM_DEVICES_IN_LIST = 20
 
 GOOGLE_MAP_ZOOM = 15
 DEFAULT_GOOGLEMAP_ICON_IMAGE = '/static/green_location_pin.png'
-GOOGLEMAP_KEY=('AIzaSyBGcqV5HgIdC-EXeO_pQOEBLrhz4bpRwZM')
+GOOGLEMAP_KEY = ('AIzaSyBGcqV5HgIdC-EXeO_pQOEBLrhz4bpRwZM')
 
 # Default viewport of map is Google's PKV office building in Seattle
 DEFAULT_MAP_CENTER = (47.6508, -122.3515)
@@ -60,4 +60,4 @@ BATTERY_INFO_INTERVAL_HOUR = 2
 MAX_QUERY_INTERVAL_DAY = 31
 
 # Timespan over which we consider a device to be active
-ACTIVE_DAYS = 5
+ACTIVE_DAYS = 50

--- a/server/gspeedometer/controllers/device.py
+++ b/server/gspeedometer/controllers/device.py
@@ -40,6 +40,7 @@ from google.appengine.ext.webapp import template
 
 from gspeedometer import config
 from gspeedometer import model
+from gspeedometer.helpers import util
 
 
 class Device(webapp.RequestHandler):
@@ -88,6 +89,8 @@ class Device(webapp.RequestHandler):
         query.with_cursor(cursor)
 
       measurements = query.fetch(config.NUM_MEASUREMENTS_IN_LIST)
+      for m in measurements:
+        m.timestamp = m.timestamp.replace(tzinfo=util.TZINFOS['utc']).astimezone(util.TZINFOS['pst'])
       # If there are more measurements to show, give the user a cursor
       if len(measurements) == config.NUM_MEASUREMENTS_IN_LIST:
         cursor = query.cursor()

--- a/server/gspeedometer/controllers/measurement.py
+++ b/server/gspeedometer/controllers/measurement.py
@@ -35,8 +35,7 @@ from gspeedometer.helpers import util
 MEASUREMENT_TYPES = [('ping', 'ping'),
                      ('dns_lookup', 'DNS lookup'),
                      ('traceroute', 'traceroute'),
-                     ('http', 'HTTP get'),
-                      ('foo', 'foobar')]
+                     ('http', 'HTTP get')]
 
 class Measurement(webapp.RequestHandler):
   """Measurement request handler."""

--- a/server/gspeedometer/controllers/measurement.py
+++ b/server/gspeedometer/controllers/measurement.py
@@ -32,15 +32,13 @@ from gspeedometer.helpers import error
 from gspeedometer.helpers import util
 
 # list of supported measurement types
-MEASUREMENT_TYPES = [('', ''),
-                     ('ping', 'ping'),
+MEASUREMENT_TYPES = [('ping', 'ping'),
                      ('dns_lookup', 'DNS lookup'),
                      ('traceroute', 'traceroute'),
                      ('http', 'HTTP get')]
 
 # map of measurement parameter names to human-readable description
-PARAM_TYPES = [('', ''),
-               ('target', 'Target (IP or hostname)'),
+PARAM_TYPES = [('target', 'Target (IP or hostname)'),
                ('location_update_distance', 'Location update distance (m)'),
                ('trigger_location_update', 'Trigger location update (bool)'),
                ('ping_timeout_sec', 'Ping timeout (seconds)'),

--- a/server/gspeedometer/controllers/measurement.py
+++ b/server/gspeedometer/controllers/measurement.py
@@ -35,32 +35,8 @@ from gspeedometer.helpers import util
 MEASUREMENT_TYPES = [('ping', 'ping'),
                      ('dns_lookup', 'DNS lookup'),
                      ('traceroute', 'traceroute'),
-                     ('http', 'HTTP get')]
-
-# map of measurement parameter names to human-readable description
-PARAM_TYPES = [('target', 'Target (IP or hostname)'),
-               ('location_update_distance', 'Location update distance (m)'),
-               ('trigger_location_update', 'Trigger location update (bool)'),
-               ('ping_timeout_sec', 'Ping timeout (seconds)'),
-               ('packet_size_byte', 'Ping packet size (bytes)'),
-               ('headers', 'HTTP headers'),
-               ('method', 'HTTP method'),
-               ('url', 'HTTP URL'),
-               ('max_hop_count', 'Traceroute max hop count'),
-               ('pings_per_hop', 'Traceroute pings per hop'),
-               ('server', 'DNS server')]
-
-# map of measurement type to supported measurement parameters
-TYPE_TO_PARAM = {'ping': ['target', 'location_update_distance',
-                          'trigger_location_update', 'ping_timeout_sec',
-                          'packet_size_byte'],
-                 'http': ['url', 'location_update_distance',
-                          'trigger_location_update', 'headers', 'method' ],
-                 'dns_lookup': ['server', 'location_update_distance',
-                                'trigger_location_update'],
-                 'traceroute': ['target', 'location_update_distance',
-                                'trigger_location_update',
-                                'max_hop_count', 'pings_per_hop']}
+                     ('http', 'HTTP get'),
+                      ('foo', 'foobar')]
 
 class Measurement(webapp.RequestHandler):
   """Measurement request handler."""

--- a/server/gspeedometer/controllers/measurement.py
+++ b/server/gspeedometer/controllers/measurement.py
@@ -16,7 +16,8 @@
 
 """Service to collect and visualize mobile network performance data."""
 
-__author__ = 'mdw@google.com (Matt Welsh)'
+__author__ = ('mdw@google.com (Matt Welsh), ' 
+              'drchoffnes@gmail.com (David Choffnes)')
 
 import logging
 
@@ -30,12 +31,38 @@ from gspeedometer.controllers import device
 from gspeedometer.helpers import error
 from gspeedometer.helpers import util
 
-MEASUREMENT_TYPES = [('ping', 'ping'),
+# list of supported measurement types
+MEASUREMENT_TYPES = [('', ''),
+                     ('ping', 'ping'),
                      ('dns_lookup', 'DNS lookup'),
                      ('traceroute', 'traceroute'),
-                     ('http', 'HTTP get'),
-                     ('ndt', 'NDT measurement')]
+                     ('http', 'HTTP get')]
 
+# map of measurement parameter names to human-readable description
+PARAM_TYPES = [('', ''),
+               ('target', 'Target (IP or hostname)'),
+               ('location_update_distance', 'Location update distance (m)'),
+               ('trigger_location_update', 'Trigger location update (bool)'),
+               ('ping_timeout_sec', 'Ping timeout (seconds)'),
+               ('packet_size_byte', 'Ping packet size (bytes)'),
+               ('headers', 'HTTP headers'),
+               ('method', 'HTTP method'),
+               ('url', 'HTTP URL'),
+               ('max_hop_count', 'Traceroute max hop count'),
+               ('pings_per_hop', 'Traceroute pings per hop'),
+               ('server', 'DNS server')]
+
+# map of measurement type to supported measurement parameters
+TYPE_TO_PARAM = {'ping': ['target', 'location_update_distance',
+                          'trigger_location_update', 'ping_timeout_sec',
+                          'packet_size_byte'],
+                 'http': ['url', 'location_update_distance',
+                          'trigger_location_update', 'headers', 'method' ],
+                 'dns_lookup': ['server', 'location_update_distance',
+                                'trigger_location_update'],
+                 'traceroute': ['target', 'location_update_distance',
+                                'trigger_location_update',
+                                'max_hop_count', 'pings_per_hop']}
 
 class Measurement(webapp.RequestHandler):
   """Measurement request handler."""

--- a/server/gspeedometer/controllers/schedule.py
+++ b/server/gspeedometer/controllers/schedule.py
@@ -187,7 +187,7 @@ class Schedule(webapp.RequestHandler):
 
     errormsg = None
     message = None
-    add_to_schedule_form = SelectType() #AddToScheduleForm()
+    add_to_schedule_form = SelectType() 
 
     task_id = self.request.get('id')
     task = model.Task.get_by_id(int(task_id))

--- a/server/gspeedometer/controllers/schedule.py
+++ b/server/gspeedometer/controllers/schedule.py
@@ -57,7 +57,7 @@ class Schedule(webapp.RequestHandler):
         else:
           measurement = \
               measurement_type.MeasurementType.Get_Default_Measurement()
-      except RuntimeError as error:
+      except RuntimeError, error:
         # occurs if someone specifies an invalid measurement type
         logging.warning('Type in POST is invalid: %s', error)                        
         self.error(501)

--- a/server/gspeedometer/helpers/measurement_type.py
+++ b/server/gspeedometer/helpers/measurement_type.py
@@ -1,0 +1,88 @@
+# Copyright 2012 University of Washington.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#!/usr/bin/python2.4
+#
+from gspeedometer.controllers import measurement
+
+"""Simple class for mapping measurement types to their fields."""
+
+__author__ = 'drchoffnes@gmail.com (David Choffnes)'
+
+from django.utils.datastructures import SortedDict
+
+class MeasurementType:
+  """Maps datastore entity and field names to human-readable ones."""
+
+  # name of the measurement type in the datastore (e.g., ping)
+  kind = "generic_measurement"
+  # human-readable name of measurement type
+  description = "Generic measurement"
+  # dictionary of field names (as stored in datastore) to human-readable 
+  # descriptions of those fields (for printing in a form)
+  field_to_description = SortedDict()
+  
+  def __init__(self, kind, description, field_to_description):
+    self.kind = kind
+    self.description = description
+    self.field_to_description = field_to_description
+    
+  @staticmethod
+  def Get_Default_Measurement():
+    """Utility method for getting the default type to show in the scheduler."""
+    return MeasurementType.Get_Measurement(measurement.MEASUREMENT_TYPES[0][0])
+  
+  @staticmethod
+  def Get_Measurement(measurement_type):
+    """Factory method for getting measurement objects for display in 
+    measurement scheduler. 
+    
+    Note that we need to pass a SortedDict to ensure that an iterator 
+    returns fields in the proper order for display.
+       
+    Args:
+      measurement_type: Name of measurement type used in datastore.
+      
+    Returns:
+      A MeasurementType object with measurement-specific details.
+    """
+    if measurement_type == 'ping':
+      return MeasurementType(
+          'ping', 'ping', SortedDict([('target', 'Target (IP or hostname)'),
+          ('location_update_distance', 'Location update distance (m)'),
+          ('trigger_location_update', 'Trigger location update (bool)'),
+          ('ping_timeout_sec', 'Ping timeout (seconds)'),
+          ('packet_size_byte', 'Ping packet size (bytes)')]))   
+    elif measurement_type == 'dns_lookup':
+      return MeasurementType(
+          'dns_lookup', 'DNS lookup',
+          SortedDict([('target', 'Target (IP or hostname)'),
+          ('location_update_distance', 'Location update distance (m)'),
+          ('trigger_location_update', 'Trigger location update (bool)'),
+           ('server', 'DNS server')]))  
+    elif measurement_type == 'traceroute':
+      return MeasurementType(
+          'traceroute', 'traceroute',
+          SortedDict([('target', 'Target (IP or hostname)'),
+          ('location_update_distance', 'Location update distance (m)'),
+          ('trigger_location_update', 'Trigger location update (bool)'),
+          ('max_hop_count', 'Traceroute max hop count'),
+          ('pings_per_hop', 'Traceroute pings per hop')]))  
+    elif measurement_type == 'http':
+      return MeasurementType(
+          'http', 'HTTP get', SortedDict([('url', 'HTTP URL'),
+          ('location_update_distance', 'Location update distance (m)'),
+          ('trigger_location_update', 'Trigger location update (bool)'),
+          ('headers', 'HTTP headers'), ('method', 'HTTP method')]))  
+    else:
+      raise RuntimeError('Invalid measurement type: %s' % measurement_type)

--- a/server/gspeedometer/helpers/measurement_type.py
+++ b/server/gspeedometer/helpers/measurement_type.py
@@ -11,15 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#!/usr/bin/python2.4
 #
-from gspeedometer.controllers import measurement
 
 """Simple class for mapping measurement types to their fields."""
 
 __author__ = 'drchoffnes@gmail.com (David Choffnes)'
 
 from django.utils.datastructures import SortedDict
+from gspeedometer.controllers import measurement
 
 class MeasurementType:
   """Maps datastore entity and field names to human-readable ones."""

--- a/server/gspeedometer/helpers/util.py
+++ b/server/gspeedometer/helpers/util.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #!/usr/bin/python2.4
 #
+import os
+import calendar
 
 """Utility functions for the Mobiperf service."""
 
@@ -133,3 +135,43 @@ def ConvertFromDict(model, input_dict, include_fields=None,
       method(v)
     else:
       setattr(model, k, v)
+
+class PstTzinfo(datetime.tzinfo):
+  def utcoffset(self, dt): return datetime.timedelta(hours= -7)
+  def dst(self, dt): return datetime.timedelta(0)
+  def tzname(self, dt): return 'PST+07PDT'
+  def olsen_name(self): return 'US/Pacific'
+  
+class UtcTzinfo(datetime.tzinfo):
+  def utcoffset(self, dt): return datetime.timedelta(hours=0)
+  def dst(self, dt): return datetime.timedelta(0)
+  def tzname(self, dt): return 'UTC'
+  def olsen_name(self): return 'UTC'
+
+TZINFOS = {
+  'pst': PstTzinfo(),
+  'utc': UtcTzinfo()
+}
+
+def translate(self, timestamp):
+    """Translates a UTC datetime to the env_tz query parameter's time zone.
+
+    Args:
+      timestamp: A datetime instance.
+
+    Returns:
+      A (str, datetime) tuple. The string is the code snippet used to
+      translate the timestamp, and the datetime is the result.
+    """
+    translate_to = self.request.get('translate_to', 'nothing')
+    translate_with = self.request.get('translate_with', 'astimezone()')
+    utc = TZINFOS['utc']
+
+    if translate_to == 'nothing':
+      return ('no translation', 'N/A')
+    elif translate_with == 'astimezone':
+      timestamp = timestamp.replace(tzinfo=utc)
+      return ('timestamp.astimezone(to_tzinfo)',
+              timestamp.astimezone(TZINFOS[translate_to]))   
+    else:
+      return ('invalid translation', 'invalid translation')

--- a/server/gspeedometer/main.py
+++ b/server/gspeedometer/main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #!/usr/bin/python2.4
 #
+from google.appengine.ext import webapp
 
 """Service to collect and visualize mobile network performance data."""
 
@@ -46,7 +47,7 @@ from gspeedometer.controllers import schedule
 from gspeedometer.controllers import timeseries
 
 import routes
-
+ 
 m = routes.Mapper()
 m.connect('/',
           controller='home:Home',

--- a/server/gspeedometer/templates/schedule.html
+++ b/server/gspeedometer/templates/schedule.html
@@ -3,7 +3,7 @@
 {% extends "base.html" %}
 
 {% block extra_meta_link %}
-  <meta http-equiv="refresh" content="60">
+  <meta http-equiv="refresh" content="600">
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
Redesigned measurement scheduler interface to facilitate adding new measurements and new parameters. Also changed the refresh interval on the page to 10 minutes instead of 1 minute, since the latter was causing input data to be lost before submission. Currently deployed at http://schedule-test.openmobiledata.appspot.com/schedule/add
