### PR TITLE
Adding utility functions for data archival process.

### DIFF
--- a/server/gspeedometer/controllers/measurement.py
+++ b/server/gspeedometer/controllers/measurement.py
@@ -106,36 +106,7 @@ class Measurement(webapp.RequestHandler):
     else:
       results = query
 
-    output = []
-    for measurement in results:
-      # Need to catch case where device has been deleted
-      try:
-        unused_device_info = measurement.device_properties.device_info
-      except db.ReferencePropertyResolveError:
-        logging.exception('Device deleted for measurement %s',
-                          measurement.key().id())
-        # Skip this measurement
-        continue
-
-      # Need to catch case where task has been deleted
-      try:
-        unused_task = measurement.task
-      except db.ReferencePropertyResolveError:
-        measurement.task = None
-        measurement.put()
-
-      mdict = util.ConvertToDict(measurement, timestamps_in_microseconds=True)
-
-      # Fill in additional fields
-      mdict['id'] = str(measurement.key().id())
-      mdict['parameters'] = measurement.Params()
-      mdict['values'] = measurement.Values()
-
-      if 'task' in mdict and mdict['task'] is not None:
-        mdict['task']['id'] = str(measurement.GetTaskID())
-        mdict['task']['parameters'] = measurement.task.Params()
-
-      output.append(mdict)
+    output = util.MeasuermentListToDictList(results)
     self.response.out.write(json.dumps(output))
 
   def MeasurementDetail(self, **unused_args):

--- a/server/gspeedometer/helpers/archive_util.py
+++ b/server/gspeedometer/helpers/archive_util.py
@@ -1,0 +1,216 @@
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#!/usr/bin/python2.4
+#
+
+"""Archive utility functions for the Mobiperf service.
+
+These functions are intended to make it easy to take data from the datastore
+serialize it, and compress it in a file format for download or storage.  The
+reliability of these methods is dependent on the implementations of the
+serialization methods in gspeeometer.helpers.util.
+
+For a simple usage example see gspeeometer.controllers.archive.
+"""
+
+__author__ = 'gavaletz@google.com (Eric Gavaletz)'
+
+import logging
+import md5
+import StringIO
+import zipfile
+
+from django.utils import simplejson as json
+
+from gspeedometer import model
+from gspeedometer.helpers import util
+
+
+def ArchivePack(model_list, include_fields=None, exclude_fields=None):
+  """Archives a list of entities from the datastore.
+
+  Provided a list of entities from the datastore this method will convert the
+  entities to JSON.  The result of this operation is a dictionary where the key
+  is the name of the kind and the value is the JSON encoded list of entities of
+  that kind.
+
+  Args:
+    model_list: A list of entities from the datastore.  The list can be of
+        mixed kinds.
+    include_fields: A list of attributes for the entities that should be
+        included in the serialized form.
+    exclude_fields: A list of attributes for the entities that should be
+        excluded in the serialized form.
+  
+  Returns:
+    A dictionary JSON strings representing the list of JSON encoded files.
+
+  Raises:
+    TypeError: Exception raised is the json library is unable to deal with one
+        of the types in the models.  The error is logged and re-raised.
+  """
+  model_dict_by_kind = dict()
+  for m in model_list:
+    kind = m.kind()
+    if not kind in model_dict_by_kind:
+      model_dict_by_kind[kind] = list()
+    model_dict_by_kind[kind].append(util.ConvertToDict(m, include_fields,
+        exclude_fields, timestamps_in_microseconds=True))
+  json_data_by_kind = dict()
+  for kind in model_dict_by_kind:
+    try:
+      json_data_by_kind[kind] = json.dumps(model_dict_by_kind[kind])
+    except TypeError, e:
+      logging.exception(e)
+      raise e
+  return json_data_by_kind
+
+
+def ArchiveUnpack(file_dict, include_fields=None, exclude_fields=None):
+  """Un-archives a list of entities from a dictionary of JSON strings.
+
+  This method undoes the process of ArchivePack.
+
+  Args:
+    file_dict: A dictionary JSON strings representing the list of JSON encoded
+        files.
+    include_fields: A list of attributes for the entities that should be
+        extracted from the serialized form.
+    exclude_fields: A list of attributes for the entities that should NOT be
+        extracted from the serialized form.
+  
+  Returns:
+    A list of models.
+
+  Raises:
+    TypeError: Exception raised is the json library is unable to deal with one
+        of the types in the models.  The error is logges and re-raised.
+  """
+  model_list = list()
+  for model_kind in file_dict:
+    model_class = model.GetClassByKind(model_kind)
+    json_data = file_dict[model_kind]
+    try:
+      model_dict_list = json.loads(json_data)
+    except TypeError, e:
+      logging.exception(e)
+      raise e
+    for model_dict in model_dict_list:
+      model_instance = model_class()
+      #TODO(mdw) this is failing and you have no unittests.
+      model_list.append(util.ConvertFromDict(model_instance, model_dict,
+          include_fields, exclude_fields))
+  return model_list
+
+
+def ArchiveCompress(file_dict, directory=None):
+  """Compresses an archive dictionary to a zip file.
+
+  Provided an archive dictionary and an optional directory name each key is
+  combined with the directory name to create a file path and the value is used
+  as the contents of the file.  The files are then compressed into a zip file
+  suitable for download or storing in BigStore.
+
+  Args:
+    file_dict: A dictionary JSON strings representing the list of JSON encoded
+        files.
+  
+  Returns:
+    A zipfile of the files represented in the archive dictionary.
+
+  Raises:
+    RuntimeError: Exception raised if the zlib module is missing or if the
+        StringIO stream is closed unexpectedly.
+  """
+  archive_stream = StringIO.StringIO()
+  try:
+    archive_file = zipfile.ZipFile(file=archive_stream,
+      compression=zipfile.ZIP_DEFLATED, mode='w')
+  except RuntimeError, e:
+    logging.exception('likely missing the zlib module: %s', e)
+    raise e
+  for member_name in file_dict:
+    if directory is None:
+      info = zipfile.ZipInfo(member_name)
+    else:
+      info = zipfile.ZipInfo('%s/%s' % (directory, member_name))
+    info.external_attr = 0644 << 16L
+    info.compress_type = zipfile.ZIP_DEFLATED
+    try:
+      archive_file.writestr(info, file_dict[member_name])
+    except RuntimeError, e:
+      logging.exception('likely FakeFile is closed or \'r\': %s', e)
+      raise e
+  archive_file.close()
+  archive_stream.seek(0)
+  return archive_stream.getvalue()
+
+
+def ArchiveDecompress(archive):
+  """Decompresses a zip file to an archive dictionary.
+
+  This method undoes the process of ArchiveCompress.
+
+  Args:
+    archive: A zipfile of the files represented in the archive dictionary.
+  
+  Returns:
+    A dictionary of strings representing the contents of the files.
+
+  Raises:
+    RuntimeError: Exception raised if the zlib module is missing or if the
+        StringIO stream is closed unexpectedly.
+  """
+  archive_stream = StringIO.StringIO(archive)
+  try:
+    archive_file = zipfile.ZipFile(file=archive_stream,
+      compression=zipfile.ZIP_DEFLATED, mode='r')
+  except RuntimeError, e:
+    logging.exception('likely missing the zlib module: %s', e)
+    raise e
+  info_list = archive_file.infolist()
+  file_dict = dict()
+  for info in info_list:
+    if '/' in info.filename:
+      model_kind = info.filename.split('/')[-1]
+    else:
+      model_kind = info.filename
+    try:
+      file_dict[model_kind] = archive_file.read(info.filename)
+    except RuntimeError, e:
+      logging.exception('likely FakeFile is closed or \'w\': %s', e)
+      raise e
+  return file_dict
+
+
+def ArchiveHash(archive):
+  """Calculates the cryptographic hash for the archive.
+
+  We are using md5 because it can be sent to Google storage as the "Content-MD5"
+  HTTP request header (used to check the integrity of the PUT operation) and it
+  can be compared to the "ETag" HTTP response header so that we can compare to a
+  known hash.
+
+  Args:
+    archive: The data that we want to calculate the md5 hash for.
+
+  Returns:
+    A string with the hexadecimal representation of the md5 hash of the data
+    supplied in the archive_string.
+
+  Raises:
+    No exceptions handled here.
+    No new exceptions generated here.
+  """
+  return md5.md5(archive).hexdigest()

--- a/server/gspeedometer/helpers/archive_util.py
+++ b/server/gspeedometer/helpers/archive_util.py
@@ -17,9 +17,7 @@
 """Archive utility functions for the Mobiperf service.
 
 These functions are intended to make it easy to take data from the datastore
-serialize it, and compress it in a file format for download or storage.  The
-reliability of these methods is dependent on the implementations of the
-serialization methods in gspeeometer.helpers.util.
+and compress it in a file format for download or storage.
 
 For a simple usage example see gspeeometer.controllers.archive.
 """
@@ -30,88 +28,6 @@ import logging
 import md5
 import StringIO
 import zipfile
-
-from django.utils import simplejson as json
-
-from gspeedometer import model
-from gspeedometer.helpers import util
-
-
-def ArchivePack(model_list, include_fields=None, exclude_fields=None):
-  """Archives a list of entities from the datastore.
-
-  Provided a list of entities from the datastore this method will convert the
-  entities to JSON.  The result of this operation is a dictionary where the key
-  is the name of the kind and the value is the JSON encoded list of entities of
-  that kind.
-
-  Args:
-    model_list: A list of entities from the datastore.  The list can be of
-        mixed kinds.
-    include_fields: A list of attributes for the entities that should be
-        included in the serialized form.
-    exclude_fields: A list of attributes for the entities that should be
-        excluded in the serialized form.
-  
-  Returns:
-    A dictionary JSON strings representing the list of JSON encoded files.
-
-  Raises:
-    TypeError: Exception raised is the json library is unable to deal with one
-        of the types in the models.  The error is logged and re-raised.
-  """
-  model_dict_by_kind = dict()
-  for m in model_list:
-    kind = m.kind()
-    if not kind in model_dict_by_kind:
-      model_dict_by_kind[kind] = list()
-    model_dict_by_kind[kind].append(util.ConvertToDict(m, include_fields,
-        exclude_fields, timestamps_in_microseconds=True))
-  json_data_by_kind = dict()
-  for kind in model_dict_by_kind:
-    try:
-      json_data_by_kind[kind] = json.dumps(model_dict_by_kind[kind])
-    except TypeError, e:
-      logging.exception(e)
-      raise e
-  return json_data_by_kind
-
-
-def ArchiveUnpack(file_dict, include_fields=None, exclude_fields=None):
-  """Un-archives a list of entities from a dictionary of JSON strings.
-
-  This method undoes the process of ArchivePack.
-
-  Args:
-    file_dict: A dictionary JSON strings representing the list of JSON encoded
-        files.
-    include_fields: A list of attributes for the entities that should be
-        extracted from the serialized form.
-    exclude_fields: A list of attributes for the entities that should NOT be
-        extracted from the serialized form.
-  
-  Returns:
-    A list of models.
-
-  Raises:
-    TypeError: Exception raised is the json library is unable to deal with one
-        of the types in the models.  The error is logges and re-raised.
-  """
-  model_list = list()
-  for model_kind in file_dict:
-    model_class = model.GetClassByKind(model_kind)
-    json_data = file_dict[model_kind]
-    try:
-      model_dict_list = json.loads(json_data)
-    except TypeError, e:
-      logging.exception(e)
-      raise e
-    for model_dict in model_dict_list:
-      model_instance = model_class()
-      #TODO(mdw) this is failing and you have no unittests.
-      model_list.append(util.ConvertFromDict(model_instance, model_dict,
-          include_fields, exclude_fields))
-  return model_list
 
 
 def ArchiveCompress(file_dict, directory=None):
@@ -155,43 +71,6 @@ def ArchiveCompress(file_dict, directory=None):
   archive_file.close()
   archive_stream.seek(0)
   return archive_stream.getvalue()
-
-
-def ArchiveDecompress(archive):
-  """Decompresses a zip file to an archive dictionary.
-
-  This method undoes the process of ArchiveCompress.
-
-  Args:
-    archive: A zipfile of the files represented in the archive dictionary.
-  
-  Returns:
-    A dictionary of strings representing the contents of the files.
-
-  Raises:
-    RuntimeError: Exception raised if the zlib module is missing or if the
-        StringIO stream is closed unexpectedly.
-  """
-  archive_stream = StringIO.StringIO(archive)
-  try:
-    archive_file = zipfile.ZipFile(file=archive_stream,
-      compression=zipfile.ZIP_DEFLATED, mode='r')
-  except RuntimeError, e:
-    logging.exception('likely missing the zlib module: %s', e)
-    raise e
-  info_list = archive_file.infolist()
-  file_dict = dict()
-  for info in info_list:
-    if '/' in info.filename:
-      model_kind = info.filename.split('/')[-1]
-    else:
-      model_kind = info.filename
-    try:
-      file_dict[model_kind] = archive_file.read(info.filename)
-    except RuntimeError, e:
-      logging.exception('likely FakeFile is closed or \'w\': %s', e)
-      raise e
-  return file_dict
 
 
 def ArchiveHash(archive):

--- a/server/gspeedometer/helpers/archive_util_test.py
+++ b/server/gspeedometer/helpers/archive_util_test.py
@@ -1,0 +1,59 @@
+# Copyright 2012 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tests for helpers/archive_util.py."""
+
+__author__ = 'gavaletz@google.com (Eric Gavaletz)'
+
+import unittest2
+
+from gspeedometer.helpers import archive_util
+
+
+class ArchiveUtilTest(unittest2.TestCase):
+  """Tests for helpers/archive_util.py."""
+  
+  FILE_CONTENT = 'Don\'t worry about people stealing an idea. If it\'s \
+original, you will have to ram it down their throats.'
+  FILE_CONTENT_MOD = 'Don\'t worry about people stealing an idea. If it\'s \
+original, you will have 2 ram it down their throats.'
+
+  #If any of the above strings change this needs to be updated.
+  FILE_CONTENT_MD5 = '811909e0f78ebd1c4b8d50a8168fea6e'
+
+  ARCHIVE = {'FILE_CONTENT': FILE_CONTENT, 'FILE_CONTENT_MOD': FILE_CONTENT_MOD}
+
+  #If any of the above strings change this needs to be updated.
+  ARCHIVE_ZIP_MD5 = 'bf15754aa282be5ff59d689fa14ee6c3'
+
+  def testArchiveHash(self):
+    """Test the hash.
+    
+    This test will fail if the type of hash generated changes.
+    """
+    gen_hash = archive_util.ArchiveHash(ArchiveUtilTest.FILE_CONTENT)
+    gen_hash_mod = archive_util.ArchiveHash(ArchiveUtilTest.FILE_CONTENT_MOD)
+    self.assertEqual(gen_hash, ArchiveUtilTest.FILE_CONTENT_MD5)
+    self.assertNotEqual(gen_hash_mod, ArchiveUtilTest.FILE_CONTENT_MD5) 
+
+  def testArchiveCompress(self):
+    """Test the compression.
+
+    This test will fail if the type of compression or the type of hash generated
+    changes.  The hash should match the md5sum generated from a local file.
+    """
+    archive_zip = archive_util.ArchiveCompress(ArchiveUtilTest.ARCHIVE)
+    gen_hash = archive_util.ArchiveHash(archive_zip)
+    self.assertEqual(gen_hash, ArchiveUtilTest.ARCHIVE_ZIP_MD5)

--- a/server/gspeedometer/helpers/util.py
+++ b/server/gspeedometer/helpers/util.py
@@ -84,6 +84,9 @@ def ConvertToDict(model, include_fields=None, exclude_fields=None,
      For each property in the model, set a value in the returned dict
      with the property name as its key.
   """
+  #TODO(mdw) deal with ReferencePropertyResolveError
+  # https://developers.google.com/appengine/docs/python/datastore/typesandpropertyclasses#ReferenceProperty
+  # ReferencePropertyResolveError: ReferenceProperty failed to be resolved: [u'Task', 34025L]
   output = {}
   for key, prop in model.properties().iteritems():
     if include_fields is not None and key not in include_fields: continue
@@ -113,6 +116,7 @@ def ConvertToJson(model, include_fields=None, exclude_fields=None):
   return json.dumps(ConvertToDict(model, include_fields, exclude_fields))
 
 
+#TODO(mdw) this is fails to undo the conversion in ConvertToDict
 def ConvertFromDict(model, input_dict, include_fields=None,
                     exclude_fields=None):
   """Fill in Model fields with values from a dict.

--- a/server/gspeedometer/model.py
+++ b/server/gspeedometer/model.py
@@ -27,37 +27,6 @@ from gspeedometer.helpers import acl
 from gspeedometer.helpers import util
 
 
-def GetClassByKind(kind):
-  """Maps the datastore entity kind to a db.Model subclass.
-
-  Used to get a reference to a entity subclass.  If you are given a serialized
-  entity and you wish to recreate the model you could use this mehtod to create
-  an instance.
-
-  Args:
-    kind: A string representing the db.Model subclass.
-  
-  Returns:
-    A reference to the appropriate db.Model subclass.
-
-  Raises:
-    NotImplementedError: Exception indicates the subclass is not implmented.
-  """
-  if kind == 'DeviceInfo':
-    return DeviceInfo
-  elif kind == 'DeviceProperties':
-    return DeviceProperties
-  elif kind == 'Task':
-    return Task
-  elif kind == 'Measurement':
-    return Measurement
-  elif kind == 'DeviceTask':
-    return DeviceTask
-  else:
-    logging.error('Unknown db.Model subclass = %s', kind)
-    raise NotImplementedError
-
-
 class DeviceInfo(db.Model):
   """Represents the static properties of a given device."""
 

--- a/server/gspeedometer/model.py
+++ b/server/gspeedometer/model.py
@@ -16,7 +16,7 @@
 
 """Data model for the Mobiperf service."""
 
-__author__ = 'mdw@google.com (Matt Welsh)'
+__author__ = 'mdw@google.com (Matt Welsh), gavaletz@google.com (Eric Gavaletz)'
 
 import logging
 
@@ -25,6 +25,37 @@ from google.appengine.ext import db
 from gspeedometer import config
 from gspeedometer.helpers import acl
 from gspeedometer.helpers import util
+
+
+def GetClassByKind(kind):
+  """Maps the datastore entity kind to a db.Model subclass.
+
+  Used to get a reference to a entity subclass.  If you are given a serialized
+  entity and you wish to recreate the model you could use this mehtod to create
+  an instance.
+
+  Args:
+    kind: A string representing the db.Model subclass.
+  
+  Returns:
+    A reference to the appropriate db.Model subclass.
+
+  Raises:
+    NotImplementedError: Exception indicates the subclass is not implmented.
+  """
+  if kind == 'DeviceInfo':
+    return DeviceInfo
+  elif kind == 'DeviceProperties':
+    return DeviceProperties
+  elif kind == 'Task':
+    return Task
+  elif kind == 'Measurement':
+    return Measurement
+  elif kind == 'DeviceTask':
+    return DeviceTask
+  else:
+    logging.error('Unknown db.Model subclass = %s', kind)
+    raise NotImplementedError
 
 
 class DeviceInfo(db.Model):


### PR DESCRIPTION
These files will be used to serialize and compress entities from the
datastore on GAE into a zip file.  Handlers for triggering these
functions will be in the next CL.

server/gspeedometer/helpers/archive_util.py - see file commentary for
details on what functions have been added.

server/gspeedometer/helpers/util.py - added a couple comments about
issues that need to be addressed.  Issues will be added in the github
issue tracker.  One problem is that it is possible to have dangling
references when some data is removed and ConvertToDict will throw a
ReferencePropertyResolveError.  The other problem is that
ConvertFromDict does not seem to be able to deal with unconverting
output from ConvertToDict in some cases.

server/gspeedometer/model.py - added a function that will take a string
and return the class that is represented by that string.  This avoids
evaluation of the string and the possible security issues that brings.
