### PR TITLE
Archive dev3 - Adding request handlers for data archival process.

### DIFF
--- a/server/app.yaml.tmpl
+++ b/server/app.yaml.tmpl
@@ -15,6 +15,10 @@ handlers:
   static_files: static/favicon.ico
   upload: static/favicon.ico
 
+- url: /admin/.*
+  script: gspeedometer/main.py
+  login: admin
+
 - url: /.*
   script: gspeedometer/main.py
   login: required

--- a/server/download_dev_data.sh
+++ b/server/download_dev_data.sh
@@ -12,7 +12,14 @@
 
 . ./script_config.sh
 
-mv $DATA_PATH $DATA_PATH.back
+DL_LOG_FILE=bulkloader-log-down
+DL_PROGRESS_FILE=bulkloader-progress-down.sql3
+DL_RESULTS_FILE=bulkloader-results-down.sql3
+
+echo "downloading data from $APP_ID.$APP_DOMAIN into $DOWNLOAD_DATA_PATH"
+echo "	--log_file=$DATA_PATH/$DL_LOG_FILE"
+echo "	--db_filename=$DATA_PATH/$DL_PROGRESS_FILE"
+echo "	--result_db_filename=$DATA_PATH/$DL_RESULTS_FILE"
 
 $PYTHON $APPCFG -e $USER_EMAIL -A s~$APP_ID download_data \
   --num_threads=10 \
@@ -21,11 +28,7 @@ $PYTHON $APPCFG -e $USER_EMAIL -A s~$APP_ID download_data \
   --rps_limit=20 \
   --http_limit=7.5 \
   --url=http://$APP_ID.$APP_DOMAIN/_ah/remote_api \
-  --log_file=$DATA_PATH/bulkloader-log-down \
-  --db_filename=$DATA_PATH/bulkloader-progress-down.sql3 \
-  --result_db_filename=$DATA_PATH/bulkloader-results-down.sql3 \
+  --log_file=$DATA_PATH/$DL_LOG_FILE \
+  --db_filename=$DATA_PATH/$DL_PROGRESS_FILE \
+  --result_db_filename=$DATA_PATH/$DL_RESULTS_FILE \
   --filename=$DOWNLOAD_DATA_PATH
-
-#TODO(user) uncomment here if you want things kept clean
-# This carries with it a risk of local data loss
-#rm $DATASTORE_PATH $DATA_PATH.back

--- a/server/download_dev_data.sh
+++ b/server/download_dev_data.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Author: gavaletz@google.com (Eric Gavaletz)
+
+# This script downloads data from the Speedometer service running on AppEngine.
+# For more information on options try "appcfg.py --help" or
+# https://developers.google.com/appengine/docs/python/tools/uploadingdata#Downloading_and_Uploading_All_Data
+
+# WARNING: this will produce a very heavy load on the GAE instance and eat up a
+# lot of the applicaion's quota.  Please check to see if there is an existing
+# download that you can use before using this.
+
+. ./script_config.sh
+
+mv $DATA_PATH $DATA_PATH.back
+
+$PYTHON $APPCFG -e $USER_EMAIL -A s~$APP_ID download_data \
+  --num_threads=10 \
+  --batch_size=10 \
+  --bandwidth_limit=1073741824 \
+  --rps_limit=20 \
+  --http_limit=7.5 \
+  --url=http://$APP_ID.$APP_DOMAIN/_ah/remote_api \
+  --log_file=$DATA_PATH/bulkloader-log-down \
+  --db_filename=$DATA_PATH/bulkloader-progress-down.sql3 \
+  --result_db_filename=$DATA_PATH/bulkloader-results-down.sql3 \
+  --filename=$DOWNLOAD_DATA_PATH
+
+#TODO(user) uncomment here if you want things kept clean
+# This carries with it a risk of local data loss
+#rm $DATASTORE_PATH $DATA_PATH.back

--- a/server/gspeedometer/config.py
+++ b/server/gspeedometer/config.py
@@ -63,7 +63,7 @@ MAX_QUERY_INTERVAL_DAY = 31
 ACTIVE_DAYS = 5
 
 #Archive Settings
-CONTENT_TYPE = 'application/zip'
-CONTENT_DISPOSITION_BASE = 'attachment; filename="%s.zip"'
-GS_BUCKET = 'gavaletz_mobiperf'
-GS_ACL = 'project-private'
+ARCHIVE_CONTENT_TYPE = 'application/zip'
+ARCHIVE_CONTENT_DISPOSITION_BASE = 'attachment; filename="%s.zip"'
+ARCHIVE_GS_BUCKET = 'gavaletz_mobiperf'
+ARCHIVE_GS_ACL = 'project-private'

--- a/server/gspeedometer/config.py
+++ b/server/gspeedometer/config.py
@@ -61,3 +61,9 @@ MAX_QUERY_INTERVAL_DAY = 31
 
 # Timespan over which we consider a device to be active
 ACTIVE_DAYS = 5
+
+#Archive Settings
+CONTENT_TYPE = 'application/zip'
+CONTENT_DISPOSITION_BASE = 'attachment; filename="%s.zip"'
+GS_BUCKET = 'gavaletz_mobiperf'
+GS_ACL = 'project-private'

--- a/server/gspeedometer/controllers/archive.py
+++ b/server/gspeedometer/controllers/archive.py
@@ -1,0 +1,230 @@
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#!/usr/bin/python2.4
+#
+
+"""Request handlers and some functions to deal with data archival.
+
+For now the only data to be archived is the measurement data.  This data is to
+be serialized, compressed and returned to the user in the form of a file 
+download or posted to BigStore (Google Storage for Developers).  
+
+Configuration for the storage location is in the global configuration file, and
+care should be taken to ensure that the data is sent to the right place and
+that the proper ACL has been established.
+
+Control for accessing these methods is set in the /server/app.yaml file and
+should be limited to those with administrative access to the datastore.  Since
+these methods will likely result in calls that will exceed the response time
+limitations for frontend instances, these requests should be handeled by
+backend instances.
+
+  Archive: A webapp.RequestHandler subclass for dealing with archive requests.
+"""
+from __future__ import with_statement
+
+__author__ = 'gavaletz@google.com (Eric Gavaletz)'
+
+import logging
+
+from google.appengine.api import files
+from google.appengine.ext import webapp
+from google.appengine.runtime import DeadlineExceededError
+
+from gspeedometer import config
+from gspeedometer import model
+from gspeedometer.helpers import archive_util
+from gspeedometer.helpers import util
+
+from django.utils import simplejson as json
+
+
+def GetMeasurementDictList(device_id, start=None, end=None):
+  """Retrieves device measurements from the datastore.
+
+  This is factored out to allow for future growth and diversification is what
+  data is retrieved and how it is filtered.
+
+  Args:
+    device_id: A string that matches a single device.
+    start: A dataetime object for the earliest measurement.
+    end: A dataetime object for the latest measurement.
+
+  Returns:
+    A list of dictionary items representing the measurement entities from the
+    datastore.
+
+  Raises:
+     No exceptions handled here.
+     No new exceptions generated here.
+  """
+  # Collect measurements
+  measurement_q = model.Measurement.all()
+  if device_id:
+    measurement_q.filter('device_id =', device_id)
+  if start:
+    measurement_q.filter('timestamp >=', start)
+  if end:
+    measurement_q.filter('timestamp <', end)
+  measurement_q.order('timestamp')
+  measurement_list = measurement_q.fetch(config.QUERY_FETCH_LIMIT)
+  return util.MeasuermentListToDictList(measurement_list)
+
+
+class Archive(webapp.RequestHandler):
+  """A webapp.RequestHandler subclass for dealing with archive requests.
+
+  These request handlers take data from the datastore and convert it to a file
+  that can be returned to the user or stored in BigStore.
+  """
+
+  def __Archive(self, **unused_args):
+    """Processes parameters and packages the data into a file-like object.
+
+    This method does the bulk of the heavy lifting.  It makes sense of the
+    request parameters, serializes the data, generates a name used to
+    encapsulate the result, and makes the call to compress the file-like
+    object.
+
+    URL Args:
+      device_id: A string key for a device in the datastore.
+      start_time: The timestamp for the earliest measurement (microseconds UTC)
+      end_time: The timestamp for the latest measurement (microseconds UTC)
+
+    All of the URL Args are optional and in the case where none are given no
+    restrictions are assumed and all the data is returned.  Since these
+    handlers should never be called by users it should be understood that this
+    case should be avoided.
+
+    Returns:
+      A name that is suitable for describing the contents of the file based on
+          the parameters for the request, and a file-like object containing the
+          measurement data.
+
+    Raises:
+       No exceptions handled here.
+       No new exceptions generated here.
+    """
+    # Make sense of parameters
+    device_id = self.request.get('device_id')
+    start_time = self.request.get('start_time')
+    end_time = self.request.get('end_time')
+    if start_time:
+      start = util.MicrosecondsSinceEpochToTime(int(start_time))
+    else:
+      start = None
+    if end_time:
+      end = util.MicrosecondsSinceEpochToTime(int(end_time))
+    else:
+      end = None
+
+    # Get data based on parameters
+    model_list = GetMeasurementDictList(device_id, start, end)
+
+    # Serialize the data
+    data = {'Measurement': json.dumps(model_list)}
+
+    # Generate directory/file name based on parameters
+    archive_dir = ''
+    if start_time:
+      archive_dir += 'S-%s' % start_time
+    if end_time:
+      if len(archive_dir):
+        archive_dir += '_'
+      archive_dir += 'E-%s' % end_time
+    if device_id:
+      if len(archive_dir):
+        archive_dir += '_'
+      archive_dir += 'I-%s' % device_id
+
+    # For some reason there was a problem with Unicode chars in the request
+    archive_dir = archive_dir.encode('ascii', 'ignore')
+    
+    #NOTE: This is a multiple return.
+    return archive_dir, archive_util.ArchiveCompress(data,
+        directory=archive_dir)
+
+  def ArchiveToFile(self, **unused_args):
+    """Responds with data in compressed JSON format for download.
+    
+    Allows a file containing the requested data to be downloaded by the user.
+    Please see __Archive for details on how arguments are handled and data is
+    packaged.
+
+    Raises:
+       DeadlineExceededError: Handled in the case where a request exceeds the
+          response time limit.  A error is displayed in the VERY short time for
+          reporting errors.
+       No new exceptions generated here.
+    """
+    try:
+      archive_dir, archive_data = self.__Archive()
+      self.response.headers['Content-Type'] = config.CONTENT_TYPE
+      cd = config.CONTENT_DISPOSITION_BASE % archive_dir  # Stupid line length.
+      self.response.headers['Content-Disposition'] = cd  # Stupid line length.
+      self.response.out.write(archive_data)
+    except DeadlineExceededError, e:
+      logging.exception(e)
+      self.response.clear()
+      self.response.set_status(500)
+      self.response.out.write('Try doing this on a backend instance...')
+
+    #TODO(gavaletz) log the archive request
+    # Consider saving the file to GS too so that it can be returned from there
+    # if requested again in the future.
+
+  def ArchiveToGs(self, **unused_args):
+    """Posts data in compressed JSON format to Google Storage for Developers.
+    
+    Allows a file containing the requested data to be stored in Google Storage
+    for developers for later download.  Please see __Archive for details on
+    how arguments are handled and data is packaged.
+
+    In preparation for use of this method it is important that the bucket and
+    account that will be used be properly prepared by following these
+    instructions (http://goo.gl/S0LRl) paying careful attention to the ACLs.
+    This information should be used to adjust the pertinent parts of this
+    application's config file.
+
+    Raises:
+       DeadlineExceededError: Handled in the case where a request exceeds the
+          response time limit.  A error is displayed in the VERY short time for
+          reporting errors.
+       No new exceptions generated here.
+    """
+    try:
+      archive_dir, archive_data = self.__Archive()
+
+      # Create the file
+      gs_archive_name = '/gs/%s/%s.zip' % (config.GS_BUCKET, archive_dir)
+      gs_archive = files.gs.create(gs_archive_name,
+          mime_type=config.CONTENT_TYPE, acl=config.GS_ACL,
+          content_disposition=config.CONTENT_DISPOSITION_BASE % archive_dir)
+
+      # Open the file and write the data.
+      with files.open(gs_archive, 'a') as f:
+        f.write(archive_data)
+
+      # Finalize (a special close) the file.
+      files.finalize(gs_archive)
+      self.response.out.write('OK -- %s' % gs_archive_name)
+    except DeadlineExceededError, e:
+      logging.exception(e)
+      self.response.clear()
+      self.response.set_status(500)
+      self.response.out.write('Try doing this on a backend instance...')
+
+    #TODO(gavaletz) create a datastore entry for the archive params, md5, etc.
+    # location might be a gs bucket, someone who downloaded it etc.
+    # with this data we do not have to do things twice.

--- a/server/gspeedometer/controllers/archive_test.py
+++ b/server/gspeedometer/controllers/archive_test.py
@@ -1,0 +1,63 @@
+# Copyright 2012 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tests for controllers/archive.py."""
+
+__author__ = 'gavaletz@google.com (Eric Gavaletz)'
+
+import unittest2
+
+from gspeedometer.controllers import archive
+
+
+class ArchiveTest(unittest2.TestCase):
+  """Tests for controllers/archive.py."""
+  
+  START = '1332979200000000'
+  END = '1333065600000000'
+  DEVICE = '351863040021202'
+
+  FN_BASE = ''
+  FN_BASE_S = 'S-%s' % START
+  FN_BASE_E = 'E-%s' % END
+  FN_BASE_D = 'I-%s' % DEVICE
+  FN_BASE_SD = '%s_%s' % (FN_BASE_S, FN_BASE_D)
+  FN_BASE_ED = '%s_%s' % (FN_BASE_E, FN_BASE_D)
+  FN_BASE_SE = '%s_%s' % (FN_BASE_S, FN_BASE_E)
+  FN_BASE_SED  = '%s_%s_%s' % (FN_BASE_S, FN_BASE_E, FN_BASE_D)
+
+  def testParametersToFileNameBase(self):
+    """Test the file name base creation based on parameters.
+    """
+    gen_base = archive.ParametersToFileNameBase()
+    self.assertEqual(gen_base, ArchiveTest.FN_BASE)
+    gen_base = archive.ParametersToFileNameBase(start_time=ArchiveTest.START)
+    self.assertEqual(gen_base, ArchiveTest.FN_BASE_S)
+    gen_base = archive.ParametersToFileNameBase(end_time=ArchiveTest.END)
+    self.assertEqual(gen_base, ArchiveTest.FN_BASE_E)
+    gen_base = archive.ParametersToFileNameBase(device_id=ArchiveTest.DEVICE)
+    self.assertEqual(gen_base, ArchiveTest.FN_BASE_D)
+    gen_base = archive.ParametersToFileNameBase(start_time=ArchiveTest.START,
+        device_id=ArchiveTest.DEVICE)
+    self.assertEqual(gen_base, ArchiveTest.FN_BASE_SD)
+    gen_base = archive.ParametersToFileNameBase(end_time=ArchiveTest.END,
+        device_id=ArchiveTest.DEVICE)
+    self.assertEqual(gen_base, ArchiveTest.FN_BASE_ED)
+    gen_base = archive.ParametersToFileNameBase(start_time=ArchiveTest.START,
+        end_time=ArchiveTest.END)
+    self.assertEqual(gen_base, ArchiveTest.FN_BASE_SE)
+    gen_base = archive.ParametersToFileNameBase(start_time=ArchiveTest.START,
+        end_time=ArchiveTest.END, device_id=ArchiveTest.DEVICE)
+    self.assertEqual(gen_base, ArchiveTest.FN_BASE_SED)

--- a/server/gspeedometer/controllers/measurement.py
+++ b/server/gspeedometer/controllers/measurement.py
@@ -106,7 +106,7 @@ class Measurement(webapp.RequestHandler):
     else:
       results = query
 
-    output = util.MeasuermentListToDictList(results)
+    output = util.MeasurementListToDictList(results)
     self.response.out.write(json.dumps(output))
 
   def MeasurementDetail(self, **unused_args):

--- a/server/gspeedometer/controllers/measurement.py
+++ b/server/gspeedometer/controllers/measurement.py
@@ -106,36 +106,7 @@ class Measurement(webapp.RequestHandler):
     else:
       results = query
 
-    output = []
-    for measurement in results:
-      # Need to catch case where device has been deleted
-      try:
-        unused_device_info = measurement.device_properties.device_info
-      except db.ReferencePropertyResolveError:
-        logging.exception('Device deleted for measurement %s',
-                          measurement.key().id())
-        # Skip this measurement
-        continue
-
-      # Need to catch case where task has been deleted
-      try:
-        unused_task = measurement.task
-      except db.ReferencePropertyResolveError:
-        measurement.task = None
-        measurement.put()
-
-      mdict = util.ConvertToDict(measurement, timestamps_in_microseconds=True)
-
-      # Fill in additional fields
-      mdict['id'] = str(measurement.key().id())
-      mdict['parameters'] = measurement.Params()
-      mdict['values'] = measurement.Values()
-
-      if 'task' in mdict and mdict['task'] is not None:
-        mdict['task']['id'] = str(measurement.GetTaskID())
-        mdict['task']['parameters'] = measurement.task.Params()
-
-      output.append(mdict)
+    output = util.MeasuermentListToDictList(results)
     self.response.out.write(json.dumps(output))
 
   def MeasurementDetail(self, **unused_args):

--- a/server/gspeedometer/helpers/archive_util.py
+++ b/server/gspeedometer/helpers/archive_util.py
@@ -54,7 +54,7 @@ def ArchiveCompress(file_dict, directory=None):
     archive_file = zipfile.ZipFile(file=archive_stream,
       compression=zipfile.ZIP_DEFLATED, mode='w')
   except RuntimeError, e:
-    logging.exception('likely missing the zlib module: %s', e)
+    logging.exception('likely missing the zlib module: ', e)
     raise e
   for member_name in file_dict:
     if directory is None:
@@ -66,7 +66,7 @@ def ArchiveCompress(file_dict, directory=None):
     try:
       archive_file.writestr(info, file_dict[member_name])
     except RuntimeError, e:
-      logging.exception('likely FakeFile is closed or \'r\': %s', e)
+      logging.exception('likely FakeFile is closed or \'r\': ', e)
       raise e
   archive_file.close()
   archive_stream.seek(0)

--- a/server/gspeedometer/helpers/archive_util.py
+++ b/server/gspeedometer/helpers/archive_util.py
@@ -1,0 +1,216 @@
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#!/usr/bin/python2.4
+#
+
+"""Archive utility functions for the Mobiperf service.
+
+These functions are intended to make it easy to take data from the datastore
+serialize it, and compress it in a file format for download or storage.  The
+reliability of these methods is dependent on the implementations of the
+serialization methods in gspeeometer.helpers.util.
+
+For a simple usage example see gspeeometer.controllers.archive.
+"""
+
+__author__ = 'gavaletz@google.com (Eric Gavaletz)'
+
+import logging
+import md5
+import StringIO
+import zipfile
+
+from django.utils import simplejson as json
+
+from gspeedometer import model
+from gspeedometer.helpers import util
+
+
+def ArchivePack(model_list, include_fields=None, exclude_fields=None):
+  """Archives a list of entities from the datastore.
+
+  Provided a list of entities from the datastore this method will convert the
+  entities to JSON.  The result of this operation is a dictionary where the key
+  is the name of the kind and the value is the JSON encoded list of entities of
+  that kind.
+
+  Args:
+    model_list: A list of entities from the datastore.  The list can be of
+        mixed kinds.
+    include_fields: A list of attributes for the entities that should be
+        included in the serialized form.
+    exclude_fields: A list of attributes for the entities that should be
+        excluded in the serialized form.
+  
+  Returns:
+    A dictionary JSON strings representing the list of JSON encoded files.
+
+  Raises:
+    TypeError: Exception raised is the json library is unable to deal with one
+        of the types in the models.  The error is logged and re-raised.
+  """
+  model_dict_by_kind = dict()
+  for m in model_list:
+    kind = m.kind()
+    if not kind in model_dict_by_kind:
+      model_dict_by_kind[kind] = list()
+    model_dict_by_kind[kind].append(util.ConvertToDict(m, include_fields,
+        exclude_fields, timestamps_in_microseconds=True))
+  json_data_by_kind = dict()
+  for kind in model_dict_by_kind:
+    try:
+      json_data_by_kind[kind] = json.dumps(model_dict_by_kind[kind])
+    except TypeError, e:
+      logging.exception(e)
+      raise e
+  return json_data_by_kind
+
+
+def ArchiveUnpack(file_dict, include_fields=None, exclude_fields=None):
+  """Un-archives a list of entities from a dictionary of JSON strings.
+
+  This method undoes the process of ArchivePack.
+
+  Args:
+    file_dict: A dictionary JSON strings representing the list of JSON encoded
+        files.
+    include_fields: A list of attributes for the entities that should be
+        extracted from the serialized form.
+    exclude_fields: A list of attributes for the entities that should NOT be
+        extracted from the serialized form.
+  
+  Returns:
+    A list of models.
+
+  Raises:
+    TypeError: Exception raised is the json library is unable to deal with one
+        of the types in the models.  The error is logges and re-raised.
+  """
+  model_list = list()
+  for model_kind in file_dict:
+    model_class = model.GetClassByKind(model_kind)
+    json_data = file_dict[model_kind]
+    try:
+      model_dict_list = json.loads(json_data)
+    except TypeError, e:
+      logging.exception(e)
+      raise e
+    for model_dict in model_dict_list:
+      model_instance = model_class()
+      #TODO(mdw) this is failing and you have no unittests.
+      model_list.append(util.ConvertFromDict(model_instance, model_dict,
+          include_fields, exclude_fields))
+  return model_list
+
+
+def ArchiveCompress(file_dict, directory=None):
+  """Compresses an archive dictionary to a zip file.
+
+  Provided an archive dictionary and an optional directory name each key is
+  combined with the directory name to create a file path and the value is used
+  as the contents of the file.  The files are then compressed into a zip file
+  suitable for download or storing in BigStore.
+
+  Args:
+    file_dict: A dictionary JSON strings representing the list of JSON encoded
+        files.
+  
+  Returns:
+    A zipfile of the files represented in the archive dictionary.
+
+  Raises:
+    RuntimeError: Exception raised if the zlib module is missing or if the
+        StringIO stream is closed unexpectedly.
+  """
+  archive_stream = StringIO.StringIO()
+  try:
+    archive_file = zipfile.ZipFile(file=archive_stream,
+      compression=zipfile.ZIP_DEFLATED, mode='w')
+  except RuntimeError, e:
+    logging.exception('likely missing the zlib module: %s', e)
+    raise e
+  for member_name in file_dict:
+    if directory is None:
+      info = zipfile.ZipInfo(member_name)
+    else:
+      info = zipfile.ZipInfo('%s/%s' % (directory, member_name))
+    info.external_attr = 0644 << 16L
+    info.compress_type = zipfile.ZIP_DEFLATED
+    try:
+      archive_file.writestr(info, file_dict[member_name])
+    except RuntimeError, e:
+      logging.exception('likely FakeFile is closed or \'r\': %s', e)
+      raise e
+  archive_file.close()
+  archive_stream.seek(0)
+  return archive_stream.getvalue()
+
+
+def ArchiveDecompress(archive):
+  """Decompresses a zip file to an archive dictionary.
+
+  This method undoes the process of ArchiveCompress.
+
+  Args:
+    archive: A zipfile of the files represented in the archive dictionary.
+  
+  Returns:
+    A dictionary of strings representing the contents of the files.
+
+  Raises:
+    RuntimeError: Exception raised if the zlib module is missing or if the
+        StringIO stream is closed unexpectedly.
+  """
+  archive_stream = StringIO.StringIO(archive)
+  try:
+    archive_file = zipfile.ZipFile(file=archive_stream,
+      compression=zipfile.ZIP_DEFLATED, mode='r')
+  except RuntimeError, e:
+    logging.exception('likely missing the zlib module: %s', e)
+    raise e
+  info_list = archive_file.infolist()
+  file_dict = dict()
+  for info in info_list:
+    if '/' in info.filename:
+      model_kind = info.filename.split('/')[-1]
+    else:
+      model_kind = info.filename
+    try:
+      file_dict[model_kind] = archive_file.read(info.filename)
+    except RuntimeError, e:
+      logging.exception('likely FakeFile is closed or \'w\': %s', e)
+      raise e
+  return file_dict
+
+
+def ArchiveHash(archive):
+  """Calculates the cryptographic hash for the archive.
+
+  We are using md5 because it can be sent to Google storage as the "Content-MD5"
+  HTTP request header (used to check the integrity of the PUT operation) and it
+  can be compared to the "ETag" HTTP response header so that we can compare to a
+  known hash.
+
+  Args:
+    archive: The data that we want to calculate the md5 hash for.
+
+  Returns:
+    A string with the hexadecimal representation of the md5 hash of the data
+    supplied in the archive_string.
+
+  Raises:
+    No exceptions handled here.
+    No new exceptions generated here.
+  """
+  return md5.md5(archive).hexdigest()

--- a/server/gspeedometer/helpers/archive_util.py
+++ b/server/gspeedometer/helpers/archive_util.py
@@ -17,9 +17,7 @@
 """Archive utility functions for the Mobiperf service.
 
 These functions are intended to make it easy to take data from the datastore
-serialize it, and compress it in a file format for download or storage.  The
-reliability of these methods is dependent on the implementations of the
-serialization methods in gspeeometer.helpers.util.
+and compress it in a file format for download or storage.
 
 For a simple usage example see gspeeometer.controllers.archive.
 """
@@ -30,88 +28,6 @@ import logging
 import md5
 import StringIO
 import zipfile
-
-from django.utils import simplejson as json
-
-from gspeedometer import model
-from gspeedometer.helpers import util
-
-
-def ArchivePack(model_list, include_fields=None, exclude_fields=None):
-  """Archives a list of entities from the datastore.
-
-  Provided a list of entities from the datastore this method will convert the
-  entities to JSON.  The result of this operation is a dictionary where the key
-  is the name of the kind and the value is the JSON encoded list of entities of
-  that kind.
-
-  Args:
-    model_list: A list of entities from the datastore.  The list can be of
-        mixed kinds.
-    include_fields: A list of attributes for the entities that should be
-        included in the serialized form.
-    exclude_fields: A list of attributes for the entities that should be
-        excluded in the serialized form.
-  
-  Returns:
-    A dictionary JSON strings representing the list of JSON encoded files.
-
-  Raises:
-    TypeError: Exception raised is the json library is unable to deal with one
-        of the types in the models.  The error is logged and re-raised.
-  """
-  model_dict_by_kind = dict()
-  for m in model_list:
-    kind = m.kind()
-    if not kind in model_dict_by_kind:
-      model_dict_by_kind[kind] = list()
-    model_dict_by_kind[kind].append(util.ConvertToDict(m, include_fields,
-        exclude_fields, timestamps_in_microseconds=True))
-  json_data_by_kind = dict()
-  for kind in model_dict_by_kind:
-    try:
-      json_data_by_kind[kind] = json.dumps(model_dict_by_kind[kind])
-    except TypeError, e:
-      logging.exception(e)
-      raise e
-  return json_data_by_kind
-
-
-def ArchiveUnpack(file_dict, include_fields=None, exclude_fields=None):
-  """Un-archives a list of entities from a dictionary of JSON strings.
-
-  This method undoes the process of ArchivePack.
-
-  Args:
-    file_dict: A dictionary JSON strings representing the list of JSON encoded
-        files.
-    include_fields: A list of attributes for the entities that should be
-        extracted from the serialized form.
-    exclude_fields: A list of attributes for the entities that should NOT be
-        extracted from the serialized form.
-  
-  Returns:
-    A list of models.
-
-  Raises:
-    TypeError: Exception raised is the json library is unable to deal with one
-        of the types in the models.  The error is logges and re-raised.
-  """
-  model_list = list()
-  for model_kind in file_dict:
-    model_class = model.GetClassByKind(model_kind)
-    json_data = file_dict[model_kind]
-    try:
-      model_dict_list = json.loads(json_data)
-    except TypeError, e:
-      logging.exception(e)
-      raise e
-    for model_dict in model_dict_list:
-      model_instance = model_class()
-      #TODO(mdw) this is failing and you have no unittests.
-      model_list.append(util.ConvertFromDict(model_instance, model_dict,
-          include_fields, exclude_fields))
-  return model_list
 
 
 def ArchiveCompress(file_dict, directory=None):
@@ -155,43 +71,6 @@ def ArchiveCompress(file_dict, directory=None):
   archive_file.close()
   archive_stream.seek(0)
   return archive_stream.getvalue()
-
-
-def ArchiveDecompress(archive):
-  """Decompresses a zip file to an archive dictionary.
-
-  This method undoes the process of ArchiveCompress.
-
-  Args:
-    archive: A zipfile of the files represented in the archive dictionary.
-  
-  Returns:
-    A dictionary of strings representing the contents of the files.
-
-  Raises:
-    RuntimeError: Exception raised if the zlib module is missing or if the
-        StringIO stream is closed unexpectedly.
-  """
-  archive_stream = StringIO.StringIO(archive)
-  try:
-    archive_file = zipfile.ZipFile(file=archive_stream,
-      compression=zipfile.ZIP_DEFLATED, mode='r')
-  except RuntimeError, e:
-    logging.exception('likely missing the zlib module: %s', e)
-    raise e
-  info_list = archive_file.infolist()
-  file_dict = dict()
-  for info in info_list:
-    if '/' in info.filename:
-      model_kind = info.filename.split('/')[-1]
-    else:
-      model_kind = info.filename
-    try:
-      file_dict[model_kind] = archive_file.read(info.filename)
-    except RuntimeError, e:
-      logging.exception('likely FakeFile is closed or \'w\': %s', e)
-      raise e
-  return file_dict
 
 
 def ArchiveHash(archive):

--- a/server/gspeedometer/helpers/archive_util_test.py
+++ b/server/gspeedometer/helpers/archive_util_test.py
@@ -1,0 +1,59 @@
+# Copyright 2012 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tests for helpers/archive_util.py."""
+
+__author__ = 'gavaletz@google.com (Eric Gavaletz)'
+
+import unittest2
+
+from gspeedometer.helpers import archive_util
+
+
+class ArchiveUtilTest(unittest2.TestCase):
+  """Tests for helpers/archive_util.py."""
+  
+  FILE_CONTENT = 'Don\'t worry about people stealing an idea. If it\'s \
+original, you will have to ram it down their throats.'
+  FILE_CONTENT_MOD = 'Don\'t worry about people stealing an idea. If it\'s \
+original, you will have 2 ram it down their throats.'
+
+  #If any of the above strings change this needs to be updated.
+  FILE_CONTENT_MD5 = '811909e0f78ebd1c4b8d50a8168fea6e'
+
+  ARCHIVE = {'FILE_CONTENT': FILE_CONTENT, 'FILE_CONTENT_MOD': FILE_CONTENT_MOD}
+
+  #If any of the above strings change this needs to be updated.
+  ARCHIVE_ZIP_MD5 = 'bf15754aa282be5ff59d689fa14ee6c3'
+
+  def testArchiveHash(self):
+    """Test the hash.
+    
+    This test will fail if the type of hash generated changes.
+    """
+    gen_hash = archive_util.ArchiveHash(ArchiveUtilTest.FILE_CONTENT)
+    gen_hash_mod = archive_util.ArchiveHash(ArchiveUtilTest.FILE_CONTENT_MOD)
+    self.assertEqual(gen_hash, ArchiveUtilTest.FILE_CONTENT_MD5)
+    self.assertNotEqual(gen_hash_mod, ArchiveUtilTest.FILE_CONTENT_MD5) 
+
+  def testArchiveCompress(self):
+    """Test the compression.
+
+    This test will fail if the type of compression or the type of hash generated
+    changes.  The hash should match the md5sum generated from a local file.
+    """
+    archive_zip = archive_util.ArchiveCompress(ArchiveUtilTest.ARCHIVE)
+    gen_hash = archive_util.ArchiveHash(archive_zip)
+    self.assertEqual(gen_hash, ArchiveUtilTest.ARCHIVE_ZIP_MD5)

--- a/server/gspeedometer/helpers/util.py
+++ b/server/gspeedometer/helpers/util.py
@@ -84,6 +84,9 @@ def ConvertToDict(model, include_fields=None, exclude_fields=None,
      For each property in the model, set a value in the returned dict
      with the property name as its key.
   """
+  #TODO(mdw) deal with ReferencePropertyResolveError
+  # https://developers.google.com/appengine/docs/python/datastore/typesandpropertyclasses#ReferenceProperty
+  # ReferencePropertyResolveError: ReferenceProperty failed to be resolved: [u'Task', 34025L]
   output = {}
   for key, prop in model.properties().iteritems():
     if include_fields is not None and key not in include_fields: continue
@@ -113,6 +116,7 @@ def ConvertToJson(model, include_fields=None, exclude_fields=None):
   return json.dumps(ConvertToDict(model, include_fields, exclude_fields))
 
 
+#TODO(mdw) this is fails to undo the conversion in ConvertToDict
 def ConvertFromDict(model, input_dict, include_fields=None,
                     exclude_fields=None):
   """Fill in Model fields with values from a dict.

--- a/server/gspeedometer/helpers/util.py
+++ b/server/gspeedometer/helpers/util.py
@@ -158,7 +158,7 @@ def MeasuermentListToDictList(measurement_list, include_fields=None,
     No New exceptions generated here.
   """
   output = list()
-  for measurement in results:
+  for measurement in measurement_list:
     # Need to catch case where device has been deleted
     try:
       unused_device_info = measurement.device_properties.device_info

--- a/server/gspeedometer/helpers/util.py
+++ b/server/gspeedometer/helpers/util.py
@@ -134,16 +134,16 @@ def ConvertFromDict(model, input_dict, include_fields=None,
     else:
       setattr(model, k, v)
 
-def MeasuermentListToDictList(measurement_list, include_fields=None,
+def MeasurementListToDictList(measurement_list, include_fields=None,
     exclude_fields=None):
   """Converts a list of measurement entities into a list of dictionaries.
 
   Given a list of measuerment model objects from the datastore, this method
   will convert that list into a list of python dictionaries that can then
-  be serailized.
+  be serialized.
 
   Args:
-    measuerment_list: A list of measurement entities from the datastore.
+    measurement_list: A list of measurement entities from the datastore.
     include_fields: A list of attributes for the entities that should be
         included in the serialized form.
     exclude_fields: A list of attributes for the entities that should be
@@ -157,6 +157,8 @@ def MeasuermentListToDictList(measurement_list, include_fields=None,
         been deleted and where task has been deleted.
     No New exceptions generated here.
   """
+  #TODO(mdw) Unit test needed.
+  #TODO(gavaletz) make this iterate over a query instead of a list.
   output = list()
   for measurement in measurement_list:
     # Need to catch case where device has been deleted

--- a/server/gspeedometer/main.py
+++ b/server/gspeedometer/main.py
@@ -108,7 +108,7 @@ m.connect('/timeseries/data',
 # Control to these handlers is controlled by the app.yaml acl lists.
 m.connect('/admin/archive/gs',
           controller='archive:Archive',
-          action='ArchiveToGs')
+          action='ArchiveToGoogleStorage')
 
 m.connect('/admin/archive/file',
           controller='archive:Archive',

--- a/server/gspeedometer/main.py
+++ b/server/gspeedometer/main.py
@@ -22,6 +22,7 @@ __author__ = 'mdw@google.com (Matt Welsh)'
 try:
   # This is expected to fail on the local server.
   from google.appengine.dist import use_library  # pylint: disable-msg=C6204
+  use_library('django', '1.2')
 except ImportError:
   pass
 else:
@@ -103,6 +104,15 @@ m.connect('/timeseries',
 m.connect('/timeseries/data',
           controller='timeseries:Timeseries',
           action='TimeseriesData')
+
+# Control to these handlers is controlled by the app.yaml acl lists.
+m.connect('/admin/archive/gs',
+          controller='archive:Archive',
+          action='ArchiveToGs')
+
+m.connect('/admin/archive/file',
+          controller='archive:Archive',
+          action='ArchiveToFile')
 
 application = wsgi.WSGIApplication(m, debug=True)
 

--- a/server/gspeedometer/model.py
+++ b/server/gspeedometer/model.py
@@ -27,37 +27,6 @@ from gspeedometer.helpers import acl
 from gspeedometer.helpers import util
 
 
-def GetClassByKind(kind):
-  """Maps the datastore entity kind to a db.Model subclass.
-
-  Used to get a reference to a entity subclass.  If you are given a serialized
-  entity and you wish to recreate the model you could use this mehtod to create
-  an instance.
-
-  Args:
-    kind: A string representing the db.Model subclass.
-  
-  Returns:
-    A reference to the appropriate db.Model subclass.
-
-  Raises:
-    NotImplementedError: Exception indicates the subclass is not implmented.
-  """
-  if kind == 'DeviceInfo':
-    return DeviceInfo
-  elif kind == 'DeviceProperties':
-    return DeviceProperties
-  elif kind == 'Task':
-    return Task
-  elif kind == 'Measurement':
-    return Measurement
-  elif kind == 'DeviceTask':
-    return DeviceTask
-  else:
-    logging.error('Unknown db.Model subclass = %s', kind)
-    raise NotImplementedError
-
-
 class DeviceInfo(db.Model):
   """Represents the static properties of a given device."""
 

--- a/server/gspeedometer/model.py
+++ b/server/gspeedometer/model.py
@@ -16,7 +16,7 @@
 
 """Data model for the Mobiperf service."""
 
-__author__ = 'mdw@google.com (Matt Welsh)'
+__author__ = 'mdw@google.com (Matt Welsh), gavaletz@google.com (Eric Gavaletz)'
 
 import logging
 
@@ -25,6 +25,37 @@ from google.appengine.ext import db
 from gspeedometer import config
 from gspeedometer.helpers import acl
 from gspeedometer.helpers import util
+
+
+def GetClassByKind(kind):
+  """Maps the datastore entity kind to a db.Model subclass.
+
+  Used to get a reference to a entity subclass.  If you are given a serialized
+  entity and you wish to recreate the model you could use this mehtod to create
+  an instance.
+
+  Args:
+    kind: A string representing the db.Model subclass.
+  
+  Returns:
+    A reference to the appropriate db.Model subclass.
+
+  Raises:
+    NotImplementedError: Exception indicates the subclass is not implmented.
+  """
+  if kind == 'DeviceInfo':
+    return DeviceInfo
+  elif kind == 'DeviceProperties':
+    return DeviceProperties
+  elif kind == 'Task':
+    return Task
+  elif kind == 'Measurement':
+    return Measurement
+  elif kind == 'DeviceTask':
+    return DeviceTask
+  else:
+    logging.error('Unknown db.Model subclass = %s', kind)
+    raise NotImplementedError
 
 
 class DeviceInfo(db.Model):

--- a/server/index.yaml
+++ b/server/index.yaml
@@ -58,3 +58,8 @@ indexes:
 # manually, move them above the marker line.  The index.yaml file is
 # automatically uploaded to the admin console when you next deploy
 # your application using appcfg.py.
+
+- kind: Measurement
+  properties:
+  - name: device_id
+  - name: timestamp

--- a/server/run_server_locally.sh
+++ b/server/run_server_locally.sh
@@ -1,23 +1,17 @@
 #!/bin/sh
 #
-# Author: mdw@google.com (Matt Welsh)
+# Author: mdw@google.com (Matt Welsh), gavaletz@google.com (Eric Gavaletz)
 
 # For more information on options try "dev_appserver.py --help" or
 # https://developers.google.com/appengine/docs/python/tools/devserver
 
-PYTHON=python
-APPSERVER=`which dev_appserver.py`
+. ./script_config.sh
 
-BLOBSTORE_PATH=dev_data
-DATASTORE_PATH=dev_data/dev_appserver.datastore
-
-CLEAN=""
-#TODO(user) if having trouble with the datastore try uncommenting this
-#CLEAN="-c"
-
-./set_version.sh --notag
-
-$PYTHON $APPSERVER $CLEAN -d .
-#TODO(user) use the following line for testing large data operations
-#$PYTHON $APPSERVER $CLEAN -d --backends --blobstore_path=$BLOBSTORE_PATH \
+$PYTHON $APPSERVER $CLEAN $DEBUG $ADDRESS .
+#TODO(user) use the following line(s) for testing large data operations
+#$PYTHON $APPSERVER $CLEAN $DEBUG $ADDRESS\
+#  --high_replication \
+#  --backends \
+#  --use_sqlite \
+#  --blobstore_path=$DATA_PATH \
 #  --datastore_path=$DATASTORE_PATH .

--- a/server/script_config.sh
+++ b/server/script_config.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Author: gavaletz@google.com (Eric Gavaletz)
+
+# Because of the growing number of scripts there was a growing number of
+# dependencies and variables being set in lots of different locations.  This
+# script is an attempt to get all of those in one place.  To use these
+# in any script simply source it as such.  
+#
+# . ./script_config.sh
+#
+# Note that this will execute the contents on this script each time that it is
+# sourced so nothing in this file should produce side effects.
+
+
+# NOTE on python versions:
+# Because a lot of systems have a default python version newer than 2.5 it is
+# necessary to be more precise about which python we want to use for running
+# the dev_appserver.  If you do not use 2.5, then it will give you warnings but
+# more importantly it is possible that you could include something that works
+# with the newer version of python that you use locally and it will break your
+# code once it is uploaded to the development GAE instance.
+
+PYTHON=python2.5
+APPCFG=`which appcfg.py`
+APPSERVER=`which dev_appserver.py`
+
+
+APP_ID=`cat app.yaml.tmpl | grep application | cut -d " " -f 2`
+APP_DOMAIN=appspot.com
+VERSION=`./set_version.sh`
+
+
+USER_EMAIL=`git config user.email`
+
+
+# These are used for downloading data from the production environment, and using
+# it with the dev_appserver.  See download_dev_data.sh and upload_local_data.sh
+# for more information.
+
+DATA_PATH=dev_data
+DOWNLOAD_DATA_PATH=$DATA_PATH/datastore.sql3
+DATASTORE_PATH=$DATA_PATH/dev_appserver.datastore
+
+
+# These are used for running the local dev_appserver.  These will not effect the
+# application as deployed on GAE.
+
+DEBUG=""
+#TODO(user) If having trouble try using this.
+#DEBUG="-d"
+
+CLEAN=""
+#TODO(user) If having trouble with the datastore try uncommenting this.
+#CLEAN="-c"
+
+ADDRESS=""
+#TODO(user) If you need to bind to a local address uncomment and adjust this.
+#ADDRESS="--address=192.168.1.128"

--- a/server/update_dev_server.sh
+++ b/server/update_dev_server.sh
@@ -6,14 +6,7 @@
 # For more information on options try "appcfg.py --help" or
 # https://developers.google.com/appengine/docs/python/tools/uploadinganapp
 
-PYTHON=python
-APPCFG=`which appcfg.py`
-
-VERSION=`./set_version.sh`
-
-APP_ID=openmobiledata
-USER_EMAIL=`git config user.email`
-APP_DOMAIN=appspot.com
+. ./script_config.sh
 
 $PYTHON $APPCFG -e $USER_EMAIL -A $APP_ID update .
 

--- a/server/upload_local_data.sh
+++ b/server/upload_local_data.sh
@@ -25,4 +25,4 @@ $PYTHON $APPCFG -e $USER_EMAIL -A dev~$APP_ID upload_data \
   --url=http://localhost:8080/_ah/remote_api \
   --log_file=$DATA_PATH/$UL_LOG_FILE \
   --db_filename=$DATA_PATH/$UL_PROGRESS_FILE \
-  --filename=$DATA_PATH
+  --filename=$DOWNLOAD_DATA_PATH

--- a/server/upload_local_data.sh
+++ b/server/upload_local_data.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Author: gavaletz@google.com (Eric Gavaletz)
+
+# This script laods data from the Speedometer service running on AppEngine to
+# dev_appserver.  For more information on options try "appcfg.py --help" or
+# https://developers.google.com/appengine/docs/python/tools/uploadingdata#Downloading_and_Uploading_All_Data
+
+# To use this you should either have obtained an sql3 file from someone that
+# has already run download_data.sh or run it yourself.  Make sure that the
+# dev_appserver is running with the datastore development options selected see
+# run_server_locally.sh for details.  This is not intended to update data on
+# the GAE instance (really you shouldn't be doing that).
+
+. ./script_config.sh
+
+$PYTHON $APPCFG -e $USER_EMAIL -A dev~$APP_ID upload_data \
+  --url=http://localhost:8080/_ah/remote_api \
+  --log_file=$DATA_PATH/bulkloader-log-up \
+  --db_filename=$DATA_PATH/bulkloader-progress-up.sql3 \
+  --filename=$DATA_PATH

--- a/server/upload_local_data.sh
+++ b/server/upload_local_data.sh
@@ -2,7 +2,7 @@
 #
 # Author: gavaletz@google.com (Eric Gavaletz)
 
-# This script laods data from the Speedometer service running on AppEngine to
+# This script loads data from the Speedometer service running on AppEngine to
 # dev_appserver.  For more information on options try "appcfg.py --help" or
 # https://developers.google.com/appengine/docs/python/tools/uploadingdata#Downloading_and_Uploading_All_Data
 
@@ -14,8 +14,15 @@
 
 . ./script_config.sh
 
+UL_LOG_FILE=bulkloader-log-up
+UL_PROGRESS_FILE=bulkloader-progress-up.sql3
+
+echo "uploading data from $DOWNLOAD_DATA_PATH into the dev_appserver"
+echo "	--log_file=$DATA_PATH/$UL_LOG_FILE"
+echo "	--db_filename=$DATA_PATH/$UL_PROGRESS_FILE"
+
 $PYTHON $APPCFG -e $USER_EMAIL -A dev~$APP_ID upload_data \
   --url=http://localhost:8080/_ah/remote_api \
-  --log_file=$DATA_PATH/bulkloader-log-up \
-  --db_filename=$DATA_PATH/bulkloader-progress-up.sql3 \
+  --log_file=$DATA_PATH/$UL_LOG_FILE \
+  --db_filename=$DATA_PATH/$UL_PROGRESS_FILE \
   --filename=$DATA_PATH


### PR DESCRIPTION
Here are the handlers to make use of the utility functions that were added late last week.  There are no unit tests on these handlers as it would only be testing things like the datastore and APIs that should be tested internally.  To try this out please use the instance at http://20120429-172305-gavaletz-94a9133.openmobiledata.appspot.com/.

I am waiting on an update from Dave on a group bucket to use.  Once that is sorted out there will be some decisions to be made on ACLs.  Since the amount of data in the datastore is pretty limited at this point, these requests are returning fine from our frontend instances, but we will want to configure these requests as backend jobs in the near future.  Another thing that we can do to reduce the load (noted as a TODO in the code) is to create an entity with the archive parameters so that when similar requests are made we can simply return the link to the pre-made file in Google Storage and not repeat our work.  Once we start keeping track of these it will be important to have the hashes for these files as well.
