### PR TITLE
Add properly IO handling on close.

### DIFF
--- a/tcpserver/src/servers/DownlinkWorker.java
+++ b/tcpserver/src/servers/DownlinkWorker.java
@@ -15,9 +15,10 @@ public class DownlinkWorker extends Thread {
   }
 
   public void run() {
+    OutputStream oStream = null;
     try {
       client.setSoTimeout(Definition.RECV_TIMEOUT);
-      OutputStream oStream = client.getOutputStream();
+      oStream = client.getOutputStream();
 
       SimpleDateFormat sDateFormat = new SimpleDateFormat("yyyyMMdd:HH:mm:ss:SSS");
       long threadId = this.getId();
@@ -35,8 +36,6 @@ public class DownlinkWorker extends Thread {
         oStream.flush();
         end = System.currentTimeMillis();
       }
-      oStream.close();
-      client.close();
       String endDate = sDateFormat.format(new Date()).toString();
       System.out.println("[" + endDate + "]" + " Downlink worker <" +
                          threadId + "> Thread ends");
@@ -44,6 +43,21 @@ public class DownlinkWorker extends Thread {
       e.printStackTrace();
       System.out.println("Downlink worker failed: port <" +
                          Definition.PORT_DOWNLINK + ">");
+    } finally {
+      if (null != oStream) {
+        try {
+          oStream.close();
+        } catch (IOException e) {
+          // nothing to be done, really; logging is probably over kill
+          System.err.println("Error closing socket output stream.");
+        }
+        try {
+          client.close();
+        } catch (IOException e) {
+          // nothing to be done, really; logging is probably over kill
+          System.err.println("Error closing socket client.");
+        }
+      }
     }
   }
 }

--- a/tcpserver/src/servers/ServerConfigWorker.java
+++ b/tcpserver/src/servers/ServerConfigWorker.java
@@ -12,22 +12,35 @@ public class ServerConfigWorker extends Thread {
   }
   
   public void run() {
+    OutputStream oStream = null;
     try {
       client.setSoTimeout(Definition.RECV_TIMEOUT);
       client.setTcpNoDelay(true);
-      OutputStream oStream = client.getOutputStream(); 
+      oStream = client.getOutputStream(); 
 
       // TODO (Haokun): Use JSON for multiple configuration data if necessary 
       byte [] finalResult = Definition.SERVER_VERSION.getBytes();
       oStream.write(finalResult, 0, finalResult.length);
       oStream.flush();
-      
-      oStream.close();
-      client.close();
     } catch (IOException e) {
       e.printStackTrace();
       System.out.println("Configuration worker failed: port <" +
                          Definition.PORT_CONFIG + ">");
+    } finally {
+      if (null != oStream) {
+        try {
+          oStream.close();
+        } catch (IOException e) {
+          // nothing to be done, really; logging is probably over kill
+          System.err.println("Error closing socket output stream.");
+        }
+        try {
+          client.close();
+        } catch (IOException e) {
+          // nothing to be done, really; logging is probably over kill
+          System.err.println("Error closing socket client.");
+        }
+      }
     }
   }
 }

--- a/tcpserver/src/servers/UplinkWorker.java
+++ b/tcpserver/src/servers/UplinkWorker.java
@@ -28,12 +28,14 @@ public class UplinkWorker extends Thread {
   }
 
   public void run() {
+    InputStream iStream = null;
+    OutputStream oStream = null;
     try {
       client.setSoTimeout(Definition.RECV_TIMEOUT);
       client.setTcpNoDelay(true);
 
-      InputStream iStream = client.getInputStream();
-      OutputStream oStream = client.getOutputStream(); 
+      iStream = client.getInputStream();
+      oStream = client.getOutputStream(); 
       SimpleDateFormat sDateFormat = new SimpleDateFormat("yyyyMMdd:HH:mm:ss:SSS");
       long threadId = this.getId();
       String startDate = sDateFormat.format(new Date()).toString();
@@ -68,9 +70,6 @@ public class UplinkWorker extends Thread {
         oStream.write(finalResult, 0, finalResult.length);
         oStream.flush();
       }      
-      oStream.close();
-      iStream.close();
-      client.close();
       String endDate = sDateFormat.format(new Date()).toString();
       System.out.println("[" + endDate + "]" + " Uplink worker <" +
                          threadId + "> Thread ends");
@@ -79,6 +78,29 @@ public class UplinkWorker extends Thread {
       e.printStackTrace();
       System.out.println("Uplink worker failed: port <" +
                          Definition.PORT_DOWNLINK + ">");
+    } finally {
+      if (null != oStream) {
+        try {
+          oStream.close();
+        } catch (IOException e) {
+          // nothing to be done, really; logging is probably over kill
+          System.err.println("Error closing socket output stream.");
+        }
+      }
+      if (null != iStream) {
+        try {
+          iStream.close();
+        } catch (IOException e) {
+          // nothing to be done, really; logging is probably over kill
+          System.err.println("Error closing socket input stream.");
+        }
+        try {
+          client.close();
+        } catch (IOException e) {
+          // nothing to be done, really; logging is probably over kill
+          System.err.println("Error closing socket client.");
+        }
+      }
     }
   }
 


### PR DESCRIPTION
On the M-Lab platform, we are seeing fairly chronic errors. I cleaned up the IO handling, especially to move close attempts to a finally block to ensure they are always attempted and hence underlying OS resources less likely to be left in inconsistent states.
