### PR TITLE
Log Mobiperf startup scripts to /var/log

### DIFF
--- a/tcpserver/initialize.sh
+++ b/tcpserver/initialize.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+exec >> /var/log/mobiperf 2>&1
+echo "####### Running /home/michigan_1/init/initialize.sh at `date` ########"
 
 set -e
 # install java JDK

--- a/tcpserver/start.sh
+++ b/tcpserver/start.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+exec >> /var/log/mobiperf 2>&1
+echo "####### Running /home/michigan_1/init/start.sh at `date` ########"
 
 cd /home/michigan_1/mobiperf
 

--- a/tcpserver/stop.sh
+++ b/tcpserver/stop.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 #this script needs to be run from the current directory
+exec >> /var/log/mobiperf 2>&1
+echo "####### Running /home/michigan_1/init/stop.sh at `date` ########"
 
 for i in Downlink Uplink ServerConfig
 do


### PR DESCRIPTION
Add an exec line to each of initialize.sh, start.sh, and stop.sh to send stdout and stderr to /var/log/mobiperf. It's been difficult to troubleshoot init problems, failures happen silently.
